### PR TITLE
Add client/home identity schema migration

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -12,6 +12,7 @@ from vivian_api.db.database import Base
 
 # Ensure model metadata is loaded before migrations run.
 from vivian_api.models import chat_models  # noqa: F401
+from vivian_api.models import identity_models  # noqa: F401
 
 
 config = context.config

--- a/apps/api/alembic/versions/20260210_0002_create_client_home_tables.py
+++ b/apps/api/alembic/versions/20260210_0002_create_client_home_tables.py
@@ -1,0 +1,100 @@
+"""Create client/home identity tables.
+
+Revision ID: 20260210_0002
+Revises: 20260208_0001
+Create Date: 2026-02-10 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260210_0002"
+down_revision: Union[str, None] = "20260208_0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "homes",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("timezone", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "clients",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("email_verified_at", sa.DateTime(), nullable=True),
+        sa.Column("password_hash", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("last_login_at", sa.DateTime(), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('active', 'disabled', 'invited')",
+            name="ck_clients_status",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email", name="uq_clients_email"),
+    )
+
+    op.create_table(
+        "home_memberships",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("home_id", sa.String(length=36), nullable=False),
+        sa.Column("client_id", sa.String(length=36), nullable=False),
+        sa.Column("role", sa.String(length=32), nullable=False),
+        sa.Column("is_default_home", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint(
+            "role IN ('owner', 'parent', 'child', 'caretaker', 'member')",
+            name="ck_home_memberships_role",
+        ),
+        sa.ForeignKeyConstraint(["client_id"], ["clients.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["home_id"], ["homes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("home_id", "client_id", name="uq_home_memberships_home_client"),
+    )
+    op.create_index(
+        op.f("ix_home_memberships_home_id"),
+        "home_memberships",
+        ["home_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_home_memberships_client_id"),
+        "home_memberships",
+        ["client_id"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_home_memberships_default_home_per_client",
+        "home_memberships",
+        ["client_id"],
+        unique=True,
+        postgresql_where=sa.text("is_default_home"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_home_memberships_default_home_per_client",
+        table_name="home_memberships",
+    )
+    op.drop_index(op.f("ix_home_memberships_client_id"), table_name="home_memberships")
+    op.drop_index(op.f("ix_home_memberships_home_id"), table_name="home_memberships")
+    op.drop_table("home_memberships")
+
+    op.drop_table("clients")
+
+    op.drop_table("homes")

--- a/apps/api/vivian_api/db/database.py
+++ b/apps/api/vivian_api/db/database.py
@@ -35,5 +35,6 @@ def init_db() -> None:
     """Create all tables (development fallback; production should use Alembic)."""
     # Import models so metadata is populated.
     from vivian_api.models.chat_models import Chat, ChatMessage  # noqa: F401
+    from vivian_api.models.identity_models import Client, Home, HomeMembership  # noqa: F401
 
     Base.metadata.create_all(bind=engine)

--- a/apps/api/vivian_api/models/__init__.py
+++ b/apps/api/vivian_api/models/__init__.py
@@ -1,0 +1,6 @@
+"""ORM models exported for metadata registration and shared imports."""
+
+from vivian_api.models.chat_models import Chat, ChatMessage
+from vivian_api.models.identity_models import Client, Home, HomeMembership
+
+__all__ = ["Chat", "ChatMessage", "Client", "Home", "HomeMembership"]

--- a/apps/api/vivian_api/models/identity_models.py
+++ b/apps/api/vivian_api/models/identity_models.py
@@ -1,0 +1,126 @@
+"""Typed SQLAlchemy ORM models for client/home identity persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import uuid
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from vivian_api.db.database import Base
+
+
+CLIENT_STATUSES = ("active", "disabled", "invited")
+MEMBERSHIP_ROLES = ("owner", "parent", "child", "caretaker", "member")
+
+
+class Home(Base):
+    """Household container shared by one or more clients."""
+
+    __tablename__ = "homes"
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    timezone: Mapped[str] = mapped_column(String(64), nullable=False, default="UTC")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    memberships: Mapped[list["HomeMembership"]] = relationship(
+        back_populates="home",
+        cascade="all, delete-orphan",
+    )
+
+
+class Client(Base):
+    """Application client/account identity."""
+
+    __tablename__ = "clients"
+    __table_args__ = (
+        UniqueConstraint("email", name="uq_clients_email"),
+        CheckConstraint(
+            "status IN ('active', 'disabled', 'invited')",
+            name="ck_clients_status",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    email: Mapped[str] = mapped_column(String(320), nullable=False)
+    email_verified_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    last_login_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    memberships: Mapped[list["HomeMembership"]] = relationship(
+        back_populates="client",
+        cascade="all, delete-orphan",
+    )
+
+
+class HomeMembership(Base):
+    """Client-to-home membership with role metadata."""
+
+    __tablename__ = "home_memberships"
+    __table_args__ = (
+        UniqueConstraint("home_id", "client_id", name="uq_home_memberships_home_client"),
+        CheckConstraint(
+            "role IN ('owner', 'parent', 'child', 'caretaker', 'member')",
+            name="ck_home_memberships_role",
+        ),
+        Index(
+            "uq_home_memberships_default_home_per_client",
+            "client_id",
+            unique=True,
+            postgresql_where=text("is_default_home"),
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    home_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("homes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    client_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("clients.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(String(32), nullable=False, default="member")
+    is_default_home: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    home: Mapped[Home] = relationship(back_populates="memberships")
+    client: Mapped[Client] = relationship(back_populates="memberships")

--- a/docs/DATABASE_TOUR.md
+++ b/docs/DATABASE_TOUR.md
@@ -10,11 +10,13 @@ This project now uses:
 
 - ORM base/session: `apps/api/vivian_api/db/database.py`
 - Typed models: `apps/api/vivian_api/models/chat_models.py`
+- Typed models: `apps/api/vivian_api/models/identity_models.py`
 - Repositories: `apps/api/vivian_api/repositories/chat_repository.py`
 - CRUD compatibility facade: `apps/api/vivian_api/crud/chat_crud.py`
 - Alembic config: `apps/api/alembic.ini`
 - Alembic env: `apps/api/alembic/env.py`
 - First migration: `apps/api/alembic/versions/20260208_0001_create_chat_tables.py`
+- Client/home migration: `apps/api/alembic/versions/20260210_0002_create_client_home_tables.py`
 
 ## Run Migrations
 


### PR DESCRIPTION
## Summary
Adds the database foundation for client/home identity while keeping this PR strictly migration/model focused.

closed #18 

## What Changed
- Added new Alembic migration:
  - `homes`
  - `clients`
  - `home_memberships`
- Added SQLAlchemy identity models for those tables.
- Registered identity models in Alembic env metadata import.
- Registered identity models in DB `init_db()` fallback import.
- Updated database tour docs with the new model/migration references.

## Schema Highlights
- `clients`
  - unique `email`
  - nullable `password_hash` (supports OAuth-first accounts)
  - `status` constrained to `active|disabled|invited`
- `home_memberships`
  - unique (`home_id`, `client_id`)
  - role constrained to `owner|parent|child|caretaker|member`
  - partial unique index enforcing at most one default home per client (`is_default_home=true`)

## Scope Control
This PR intentionally does **not** include:
- auth endpoints / JWT flow (#20)
- OAuth token storage migration/encryption (#16)
- Google IDs/settings migration to DB (#7)

## Related Issues
- #18
- #20
- #16
- #7

## Verification
- `python3 -m compileall apps/api/vivian_api`

Note: local API venv currently does not have `alembic`/`sqlalchemy` installed, so migration execution via CLI could not be run from that environment in this pass.
