### PR TITLE
Add identity schema: users, homes, memberships with seed script

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -24,7 +24,9 @@ fi
 # Add helpful aliases
 alias test-mcp="cd apps/test-mcp-server && source venv/bin/activate && pytest tests/ -v"
 alias test-all="pytest"
+alias seed-id="docker compose exec -T api python scripts/seed_identity.py"
 
 echo "🚀 Vivian Backend ready!"
 echo "   Run tests: pytest"
 echo "   Run MCP tests only: test-mcp"
+echo "   Seed identity data: seed-id --home-name \"My Home\" --seed-all-roles"

--- a/README.md
+++ b/README.md
@@ -150,6 +150,56 @@ alembic -c alembic.ini upgrade head
 For a quick walkthrough of models/repositories/migrations, see:
 `docs/DATABASE_TOUR.md`
 
+### Seed Identity Data (Home + Users + Memberships)
+
+Use the seed utility to create or update a test home and related users.
+The script uses `find_or_create` behavior for users/memberships.
+Each run always creates a new `home` row.
+
+Recommended (uses API container environment):
+
+```bash
+seed-id \
+  --home-name "Demo Home" \
+  --timezone "America/Chicago" \
+  --client "owner@example.com:owner:default" \
+  --client "parent@example.com:parent" \
+  --client "child@example.com:child" \
+  --password "owner@example.com:ChangeMe123!"
+```
+
+Equivalent direct command (without alias):
+
+```bash
+docker compose exec -T api python scripts/seed_identity.py \
+  --home-name "Demo Home" \
+  --timezone "America/Chicago" \
+  --client "owner@example.com:owner:default" \
+  --client "parent@example.com:parent" \
+  --client "child@example.com:child" \
+  --password "owner@example.com:ChangeMe123!"
+```
+
+Auto-create one member for each role:
+
+```bash
+seed-id \
+  --home-name "Demo Home" \
+  --timezone "America/Chicago" \
+  --seed-all-roles \
+  --default-email-domain "demo.local"
+```
+
+Notes:
+- Membership roles: `owner`, `parent`, `child`, `caretaker`, `guest`, `member`.
+- `--client` format is `email:role[:default]`.
+- If you omit `--client`, the script auto-seeds one user for each role.
+- `--seed-all-roles` can be combined with `--client`; duplicate email+role pairs are deduped.
+- Home names are not deduped; duplicate names are allowed.
+- Seeded memberships are marked `is_default_home=true` for all seeded users.
+- `--password` is only applied for role `owner`; non-owner roles are always saved with empty password hash.
+- Hash format uses PBKDF2-SHA256 with per-password random salt.
+
 ### Using Docker
 
 ```bash

--- a/apps/api/alembic/versions/20260210_0003_update_home_membership_roles.py
+++ b/apps/api/alembic/versions/20260210_0003_update_home_membership_roles.py
@@ -1,0 +1,35 @@
+"""Update home membership role constraint to add guest role.
+
+Revision ID: 20260210_0003
+Revises: 20260210_0002
+Create Date: 2026-02-10 11:20:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260210_0003"
+down_revision: Union[str, None] = "20260210_0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_home_memberships_role", "home_memberships", type_="check")
+    op.create_check_constraint(
+        "ck_home_memberships_role",
+        "home_memberships",
+        "role IN ('owner', 'parent', 'child', 'caretaker', 'guest', 'member')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_home_memberships_role", "home_memberships", type_="check")
+    op.create_check_constraint(
+        "ck_home_memberships_role",
+        "home_memberships",
+        "role IN ('owner', 'parent', 'child', 'caretaker', 'member')",
+    )

--- a/apps/api/alembic/versions/20260210_0004_rename_clients_to_users.py
+++ b/apps/api/alembic/versions/20260210_0004_rename_clients_to_users.py
@@ -1,0 +1,29 @@
+"""Rename clients table to users.
+
+Revision ID: 20260210_0004
+Revises: 20260210_0003
+Create Date: 2026-02-10 12:05:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260210_0004"
+down_revision: Union[str, None] = "20260210_0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.rename_table("clients", "users")
+    op.execute("ALTER TABLE users RENAME CONSTRAINT uq_clients_email TO uq_users_email")
+    op.execute("ALTER TABLE users RENAME CONSTRAINT ck_clients_status TO ck_users_status")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE users RENAME CONSTRAINT ck_users_status TO ck_clients_status")
+    op.execute("ALTER TABLE users RENAME CONSTRAINT uq_users_email TO uq_clients_email")
+    op.rename_table("users", "clients")

--- a/apps/api/scripts/seed_identity.py
+++ b/apps/api/scripts/seed_identity.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Seed homes/users/memberships for local development."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+from importlib import import_module
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import secrets
+import sys
+
+SCRIPT_PATH = Path(__file__).resolve()
+if (SCRIPT_PATH.parents[1] / "vivian_api").exists:
+    # Running from apps/api/scripts/seed_identity.py
+    API_DIR = SCRIPT_PATH.parents[1]
+elif (SCRIPT_PATH.parents[1] / "apps" / "api" / "vivian_api").exists:
+    # Running from repo-level scripts/seed_identity.py
+    API_DIR = SCRIPT_PATH.parents[1] / "apps" / "api"
+else:
+    API_DIR = SCRIPT_PATH.parents[1]
+
+if str(API_DIR) not in sys.path:
+    sys.path.insert(0, str(API_DIR))
+
+# Keep compatibility with Docker env naming.
+if not os.environ.get("DATABASE_URL") and os.environ.get("VIVIAN_API_DATABASE_URL"):
+    os.environ["DATABASE_URL"] = os.environ["VIVIAN_API_DATABASE_URL"]
+
+ROLE_ALIASES = {}
+PBKDF2_ITERATIONS = 390000
+DEFAULT_CLIENT_STATUSES = ("active", "disabled", "invited")
+DEFAULT_MEMBERSHIP_ROLES = ("owner", "parent", "child", "caretaker", "guest", "member")
+
+
+def _runtime_deps():
+    sqlalchemy = import_module("sqlalchemy")
+    select = sqlalchemy.select
+    SessionLocal = import_module("vivian_api.db.database").SessionLocal
+    identity_models = import_module("vivian_api.models.identity_models")
+    return {
+        "select": select,
+        "SessionLocal": SessionLocal,
+        "CLIENT_STATUSES": tuple(identity_models.CLIENT_STATUSES),
+        "MEMBERSHIP_ROLES": tuple(identity_models.MEMBERSHIP_ROLES),
+        "Client": identity_models.Client,
+        "Home": identity_models.Home,
+        "HomeMembership": identity_models.HomeMembership,
+    }
+
+
+@dataclass
+class ClientSeedSpec:
+    email: str
+    role: str
+    is_default_home: bool
+
+
+def _normalize_email(value: str) -> str:
+    return value.strip().lower()
+
+
+def _parse_client_spec(raw_spec: str, membership_roles: tuple[str, ...]) -> ClientSeedSpec:
+    # Format: email:role[:default]
+    parts = [p.strip() for p in raw_spec.split(":")]
+    if len(parts) < 2 or len(parts) > 3:
+        raise ValueError(
+            f"Invalid --client value '{raw_spec}'. Use email:role[:default]."
+        )
+
+    email = _normalize_email(parts[0])
+    role = ROLE_ALIASES.get(parts[1].lower(), parts[1].lower())
+    if role not in membership_roles:
+        raise ValueError(
+            f"Invalid role '{parts[1]}'. Allowed roles: "
+            f"{', '.join(membership_roles)}."
+        )
+
+    is_default = False
+    if len(parts) == 3:
+        marker = parts[2].lower()
+        is_default = marker in {"default", "true", "1", "yes"}
+
+    return ClientSeedSpec(email=email, role=role, is_default_home=is_default)
+
+
+def _parse_password_map(raw_values: list[str] | None) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for raw in raw_values or []:
+        email, sep, password = raw.partition(":")
+        if not sep:
+            raise ValueError(
+                f"Invalid --password value '{raw}'. Use email:plain_password."
+            )
+        normalized_email = _normalize_email(email)
+        if not normalized_email:
+            raise ValueError(f"Invalid --password value '{raw}'. Email is required.")
+        if not password:
+            raise ValueError(f"Invalid --password value '{raw}'. Password is required.")
+        mapping[normalized_email] = password
+    return mapping
+
+
+def _dedupe_client_specs(specs: list[ClientSeedSpec]) -> list[ClientSeedSpec]:
+    deduped: dict[tuple[str, str], ClientSeedSpec] = {}
+    for spec in specs:
+        deduped[(spec.email, spec.role)] = spec
+    return list(deduped.values())
+
+
+def _auto_role_specs(
+    *,
+    membership_roles: tuple[str, ...],
+    default_email_domain: str,
+) -> list[ClientSeedSpec]:
+    specs: list[ClientSeedSpec] = []
+    for role in membership_roles:
+        local_part = role.replace("_", "-")
+        email = f"{local_part}@{default_email_domain}"
+        specs.append(
+            ClientSeedSpec(
+                email=email,
+                role=role,
+                is_default_home=True,
+            )
+        )
+    return specs
+
+
+def _hash_password(password: str) -> str:
+    salt = secrets.token_bytes(16)
+    dk = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        PBKDF2_ITERATIONS,
+    )
+    salt_b64 = base64.urlsafe_b64encode(salt).decode("utf-8")
+    hash_b64 = base64.urlsafe_b64encode(dk).decode("utf-8")
+    return f"pbkdf2_sha256${PBKDF2_ITERATIONS}${salt_b64}${hash_b64}"
+
+
+def _create_home(home_name: str, timezone: str) -> Home:
+    deps = _runtime_deps()
+    SessionLocal = deps["SessionLocal"]
+    Home = deps["Home"]
+
+    with SessionLocal() as db:
+        home = Home(name=home_name, timezone=timezone)
+        db.add(home)
+        db.commit()
+        db.refresh(home)
+        return home
+
+
+def _find_or_create_client(
+    *,
+    email: str,
+    status: str,
+    plain_password: str | None,
+    force_empty_password: bool = False,
+) -> tuple[Client, bool]:
+    deps = _runtime_deps()
+    select = deps["select"]
+    SessionLocal = deps["SessionLocal"]
+    Client = deps["Client"]
+
+    with SessionLocal() as db:
+        client = db.scalar(select(Client).where(Client.email == email))
+        created = False
+        if client is None:
+            client = Client(email=email, status=status)
+            if force_empty_password:
+                client.password_hash = None
+            elif plain_password:
+                client.password_hash = _hash_password(plain_password)
+            db.add(client)
+            db.commit()
+            db.refresh(client)
+            created = True
+            return client, created
+
+        updated = False
+        if client.status != status:
+            client.status = status
+            updated = True
+        if force_empty_password and client.password_hash is not None:
+            client.password_hash = None
+            updated = True
+        elif plain_password:
+            client.password_hash = _hash_password(plain_password)
+            updated = True
+        if updated:
+            db.commit()
+            db.refresh(client)
+
+        return client, created
+
+
+def _upsert_membership(
+    *,
+    home_id: str,
+    client_id: str,
+    role: str,
+    is_default_home: bool,
+) -> tuple[HomeMembership, bool]:
+    deps = _runtime_deps()
+    select = deps["select"]
+    SessionLocal = deps["SessionLocal"]
+    HomeMembership = deps["HomeMembership"]
+
+    with SessionLocal() as db:
+        membership = db.scalar(
+            select(HomeMembership).where(
+                HomeMembership.home_id == home_id,
+                HomeMembership.client_id == client_id,
+            )
+        )
+        created = False
+        if membership is None:
+            membership = HomeMembership(
+                home_id=home_id,
+                client_id=client_id,
+                role=role,
+                is_default_home=is_default_home,
+            )
+            db.add(membership)
+            created = True
+        else:
+            membership.role = role
+            membership.is_default_home = is_default_home
+
+        if is_default_home:
+            other_defaults = db.scalars(
+                select(HomeMembership).where(
+                    HomeMembership.client_id == client_id,
+                    HomeMembership.home_id != home_id,
+                    HomeMembership.is_default_home.is_(True),
+                )
+            ).all()
+            for other in other_defaults:
+                other.is_default_home = False
+
+        db.commit()
+        db.refresh(membership)
+        return membership, created
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed user/home identity rows.")
+    parser.add_argument("--home-name", required=True, help="Home display name.")
+    parser.add_argument(
+        "--timezone",
+        default="UTC",
+        help="Home timezone (default: UTC).",
+    )
+    parser.add_argument(
+        "--client",
+        action="append",
+        help="User spec: email:role[:default]. Repeat for multiple users.",
+    )
+    parser.add_argument(
+        "--seed-all-roles",
+        action="store_true",
+        help=(
+            "Auto-create one user for each membership role. "
+            "Generated emails use --default-email-domain."
+        ),
+    )
+    parser.add_argument(
+        "--default-email-domain",
+        default="example.com",
+        help="Email domain for auto-generated role members (default: example.com).",
+    )
+    parser.add_argument(
+        "--password",
+        action="append",
+        help="Optional password mapping: email:plain_password. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--status",
+        default="active",
+        choices=DEFAULT_CLIENT_STATUSES,
+        help="User status for all supplied users (default: active).",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    deps = _runtime_deps()
+    membership_roles = deps["MEMBERSHIP_ROLES"]
+    client_specs = [
+        _parse_client_spec(raw_spec, membership_roles) for raw_spec in (args.client or [])
+    ]
+    if args.seed_all_roles or not client_specs:
+        client_specs.extend(
+            _auto_role_specs(
+                membership_roles=membership_roles,
+                default_email_domain=args.default_email_domain.strip().lower(),
+            )
+        )
+    client_specs = _dedupe_client_specs(client_specs)
+    password_map = _parse_password_map(args.password)
+
+    home = _create_home(args.home_name.strip(), args.timezone.strip())
+    print(f"Created home: {home.name} ({home.timezone}) id={home.id}")
+
+    for spec in client_specs:
+        spec.is_default_home = True
+        is_owner = spec.role == "owner"
+        plain_password = password_map.get(spec.email) if is_owner else None
+        force_empty_password = not is_owner
+        if not is_owner and spec.email in password_map:
+            print(
+                f"Ignoring --password for non-owner role '{spec.role}' "
+                f"({spec.email}); password remains empty."
+            )
+
+        client, client_created = _find_or_create_client(
+            email=spec.email,
+            status=args.status,
+            plain_password=plain_password,
+            force_empty_password=force_empty_password,
+        )
+        print(
+            f"{'Created' if client_created else 'Found'} client: "
+            f"{client.email} id={client.id}"
+        )
+
+        membership, membership_created = _upsert_membership(
+            home_id=home.id,
+            client_id=client.id,
+            role=spec.role,
+            is_default_home=spec.is_default_home,
+        )
+        print(
+            f"{'Created' if membership_created else 'Updated'} membership: "
+            f"client={client.email} role={membership.role} "
+            f"default={membership.is_default_home} id={membership.id}"
+        )
+
+    print("Identity seeding complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/vivian_api/db/database.py
+++ b/apps/api/vivian_api/db/database.py
@@ -35,6 +35,6 @@ def init_db() -> None:
     """Create all tables (development fallback; production should use Alembic)."""
     # Import models so metadata is populated.
     from vivian_api.models.chat_models import Chat, ChatMessage  # noqa: F401
-    from vivian_api.models.identity_models import Client, Home, HomeMembership  # noqa: F401
+    from vivian_api.models.identity_models import Home, HomeMembership, User  # noqa: F401
 
     Base.metadata.create_all(bind=engine)

--- a/apps/api/vivian_api/models/__init__.py
+++ b/apps/api/vivian_api/models/__init__.py
@@ -1,6 +1,6 @@
 """ORM models exported for metadata registration and shared imports."""
 
 from vivian_api.models.chat_models import Chat, ChatMessage
-from vivian_api.models.identity_models import Client, Home, HomeMembership
+from vivian_api.models.identity_models import Client, Home, HomeMembership, User
 
-__all__ = ["Chat", "ChatMessage", "Client", "Home", "HomeMembership"]
+__all__ = ["Chat", "ChatMessage", "User", "Client", "Home", "HomeMembership"]

--- a/apps/api/vivian_api/models/identity_models.py
+++ b/apps/api/vivian_api/models/identity_models.py
@@ -21,11 +21,11 @@ from vivian_api.db.database import Base
 
 
 CLIENT_STATUSES = ("active", "disabled", "invited")
-MEMBERSHIP_ROLES = ("owner", "parent", "child", "caretaker", "member")
+MEMBERSHIP_ROLES = ("owner", "parent", "child", "caretaker", "guest", "member")
 
 
 class Home(Base):
-    """Household container shared by one or more clients."""
+    """Household container shared by one or more users."""
 
     __tablename__ = "homes"
 
@@ -47,15 +47,15 @@ class Home(Base):
     )
 
 
-class Client(Base):
-    """Application client/account identity."""
+class User(Base):
+    """Application user/account identity."""
 
-    __tablename__ = "clients"
+    __tablename__ = "users"
     __table_args__ = (
-        UniqueConstraint("email", name="uq_clients_email"),
+        UniqueConstraint("email", name="uq_users_email"),
         CheckConstraint(
             "status IN ('active', 'disabled', 'invited')",
-            name="ck_clients_status",
+            name="ck_users_status",
         ),
     )
 
@@ -81,13 +81,13 @@ class Client(Base):
 
 
 class HomeMembership(Base):
-    """Client-to-home membership with role metadata."""
+    """User-to-home membership with role metadata."""
 
     __tablename__ = "home_memberships"
     __table_args__ = (
         UniqueConstraint("home_id", "client_id", name="uq_home_memberships_home_client"),
         CheckConstraint(
-            "role IN ('owner', 'parent', 'child', 'caretaker', 'member')",
+            "role IN ('owner', 'parent', 'child', 'caretaker', 'guest', 'member')",
             name="ck_home_memberships_role",
         ),
         Index(
@@ -109,7 +109,7 @@ class HomeMembership(Base):
     )
     client_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("clients.id", ondelete="CASCADE"),
+        ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -123,4 +123,8 @@ class HomeMembership(Base):
     )
 
     home: Mapped[Home] = relationship(back_populates="memberships")
-    client: Mapped[Client] = relationship(back_populates="memberships")
+    client: Mapped[User] = relationship(back_populates="memberships")
+
+
+# Backward-compatible alias while references migrate from Client -> User.
+Client = User

--- a/docs/DATABASE_TOUR.md
+++ b/docs/DATABASE_TOUR.md
@@ -16,7 +16,8 @@ This project now uses:
 - Alembic config: `apps/api/alembic.ini`
 - Alembic env: `apps/api/alembic/env.py`
 - First migration: `apps/api/alembic/versions/20260208_0001_create_chat_tables.py`
-- Client/home migration: `apps/api/alembic/versions/20260210_0002_create_client_home_tables.py`
+- User/home migration: `apps/api/alembic/versions/20260210_0002_create_client_home_tables.py`
+- Table rename migration: `apps/api/alembic/versions/20260210_0004_rename_clients_to_users.py`
 
 ## Run Migrations
 


### PR DESCRIPTION
## Summary

This PR implements the core identity schema for the Vivian backend, including user management, home entities, and membership relationships.

## Changes

### Database Schema
- **New migrations:**
  - `20260210_0002_create_client_home_tables.py` - Creates `homes`, `users` (formerly `clients`), and `home_memberships` tables
  - `20260210_0003_update_home_membership_roles.py` - Adds `guest` role to membership roles
  - `20260210_0004_rename_clients_to_users.py` - Renames `clients` table to `users` with constraint updates

- **Model updates (`identity_models.py`):**
  - Renamed `Client` model to `User` (maintains backward-compatible `Client` alias)
  - Added `guest` role to `MEMBERSHIP_ROLES`
  - Updated all references from "clients" to "users"

### Seeding Tool
- Added `apps/api/scripts/seed_identity.py` - A comprehensive CLI tool for creating test homes, users, and memberships
- Supports custom or auto-generated users for all membership roles (owner, parent, child, caretaker, guest, member)
- Includes PBKDF2-SHA256 password hashing for owner accounts
- Added `seed-id` alias to `.envrc` for convenient Docker-based usage

### Documentation
- Updated `README.md` with detailed seeding instructions and examples
- Updated `docs/DATABASE_TOUR.md` with new migration references

## Migration Notes
- The `Client` model remains available as an alias to `User` for backward compatibility during the transition
- All existing foreign key relationships are properly updated to reference the new `users` table

## Testing
Run the seed script to create test data:
```bash
seed-id --home-name "Test Home" --seed-all-roles
```