### PR TITLE
Add MCP tool to append cash charitable donations to ledger

### DIFF
--- a/apps/api/tests/test_follow_up_questions.py
+++ b/apps/api/tests/test_follow_up_questions.py
@@ -1,0 +1,84 @@
+"""Tests for structured follow-up question helpers."""
+
+from __future__ import annotations
+
+from vivian_api.chat.follow_up_questions import (
+    build_missing_fields_follow_up_question,
+    extract_donation_updates_from_message,
+)
+
+
+def test_build_missing_fields_follow_up_question_includes_template_and_pending_merge():
+    question_bundle = build_missing_fields_follow_up_question(
+        tool_name="append_cash_charitable_donation_to_ledger",
+        server_id="charitable_ledger",
+        arguments={
+            "donation_json": {
+                "amount": 100,
+            },
+            "check_duplicates": True,
+        },
+        raw_tool_output="""
+        {
+          "success": false,
+          "error": "Missing required donation fields: organization name, donation date.",
+          "missing_fields": ["organization_name", "donation_date"],
+          "normalized_donation_json": {"amount": 100.0, "description": "Cash donation"}
+        }
+        """,
+    )
+
+    assert question_bundle is not None
+    question, pending = question_bundle
+    assert question["tool_name"] == "append_cash_charitable_donation_to_ledger"
+    assert question["server_id"] == "charitable_ledger"
+    assert question["missing_fields"] == ["organization_name", "donation_date"]
+    assert "Please reply with" in question["prompt"]
+    assert "organization_name:" in question["prompt"]
+    assert pending["arguments"]["donation_json"]["amount"] == 100.0
+    assert pending["arguments"]["donation_json"]["description"] == "Cash donation"
+
+
+def test_extract_donation_updates_from_message_parses_labeled_text():
+    updates = extract_donation_updates_from_message(
+        "organization: Luminary Coffee House, date: 2026-02-23, amount: $100.00",
+        ["organization_name", "donation_date", "amount"],
+    )
+
+    assert updates["organization_name"] == "Luminary Coffee House"
+    assert updates["donation_date"] == "2026-02-23"
+    assert updates["amount"] == "100.00"
+
+
+def test_extract_donation_updates_from_message_parses_json_aliases():
+    updates = extract_donation_updates_from_message(
+        '{"organization":"Luminary Coffee House","date":"02/23/2026","amount":100}',
+        ["organization_name", "donation_date", "amount"],
+    )
+
+    assert updates["organization_name"] == "Luminary Coffee House"
+    assert updates["donation_date"] == "02/23/2026"
+    assert updates["amount"] == 100
+
+
+def test_extract_donation_updates_from_message_single_org_fallback():
+    updates = extract_donation_updates_from_message(
+        "Luminary Coffee House",
+        ["organization_name"],
+    )
+
+    assert updates == {"organization_name": "Luminary Coffee House"}
+
+
+def test_extract_donation_updates_from_message_cash_confirmation_yes_no():
+    yes_updates = extract_donation_updates_from_message(
+        "cash_confirmation: yes",
+        ["cash_confirmation"],
+    )
+    no_updates = extract_donation_updates_from_message(
+        "has_receipt: yes",
+        ["cash_confirmation"],
+    )
+
+    assert yes_updates == {"cash_confirmation": True}
+    assert no_updates == {"cash_confirmation": False}

--- a/apps/api/vivian_api/chat/follow_up_questions.py
+++ b/apps/api/vivian_api/chat/follow_up_questions.py
@@ -1,0 +1,339 @@
+"""Structured follow-up question helpers for missing tool input fields."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any
+
+
+FIELD_SPECS: dict[str, dict[str, str]] = {
+    "organization_name": {
+        "label": "Organization name",
+        "type": "text",
+        "placeholder": "<Organization name>",
+    },
+    "donation_date": {
+        "label": "Donation date",
+        "type": "date",
+        "placeholder": "<YYYY-MM-DD>",
+    },
+    "amount": {
+        "label": "Donation amount",
+        "type": "number",
+        "placeholder": "<Amount>",
+    },
+    "cash_confirmation": {
+        "label": "Cash donation?",
+        "type": "text",
+        "placeholder": "<yes/no>",
+    },
+}
+
+
+def _parse_json_object(raw: str) -> dict[str, Any] | None:
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _first_non_empty(payload: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        value = payload.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str) and not value.strip():
+            continue
+        return value
+    return None
+
+
+def _sanitize_candidate(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if re.fullmatch(r"<[^>]+>", normalized):
+        return None
+    if normalized.lower() in {"organization name", "yyyy-mm-dd", "amount", "yes/no"}:
+        return None
+    return normalized
+
+
+def _coerce_boolish(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip().lower()
+    if not text:
+        return None
+    if text in {"true", "1", "yes", "y", "cash", "confirmed", "confirm"}:
+        return True
+    if text in {"false", "0", "no", "n", "not cash"}:
+        return False
+    if text in {"card", "credit", "credit card", "debit", "debit card", "check", "ach", "wire"}:
+        return False
+    return None
+
+
+def build_missing_fields_follow_up_question(
+    *,
+    tool_name: str,
+    server_id: str,
+    arguments: dict[str, Any],
+    raw_tool_output: str,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Build question + pending state from a tool output payload."""
+    payload = _parse_json_object(raw_tool_output)
+    if not payload:
+        return None
+
+    raw_missing = payload.get("missing_fields")
+    if not isinstance(raw_missing, list):
+        return None
+
+    missing_fields = [str(item).strip() for item in raw_missing if str(item).strip()]
+    if not missing_fields:
+        return None
+
+    fields: list[dict[str, Any]] = []
+    for key in missing_fields:
+        spec = FIELD_SPECS.get(key)
+        if spec:
+            fields.append(
+                {
+                    "key": key,
+                    "label": spec["label"],
+                    "type": spec["type"],
+                    "required": True,
+                    "placeholder": spec["placeholder"],
+                }
+            )
+        else:
+            fields.append(
+                {
+                    "key": key,
+                    "label": key.replace("_", " ").title(),
+                    "type": "text",
+                    "required": True,
+                    "placeholder": "",
+                }
+            )
+
+    suggested_values = payload.get("normalized_donation_json")
+    if not isinstance(suggested_values, dict):
+        suggested_values = {}
+
+    pending_arguments = dict(arguments or {})
+    if isinstance(pending_arguments.get("donation_json"), dict) and suggested_values:
+        merged = dict(pending_arguments["donation_json"])
+        for key, value in suggested_values.items():
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            merged[key] = value
+        pending_arguments["donation_json"] = merged
+
+    prompt_base = str(payload.get("error") or "I need a few details before I can continue.").strip()
+    if not prompt_base:
+        prompt_base = "I need a few details before I can continue."
+
+    template_lines = []
+    for field in fields:
+        key = field["key"]
+        suggested = suggested_values.get(key)
+        placeholder = field.get("placeholder") or "<value>"
+        if isinstance(suggested, str) and suggested.strip():
+            value = suggested.strip()
+        elif suggested is not None and not isinstance(suggested, str):
+            value = str(suggested)
+        else:
+            value = placeholder
+        template_lines.append(f"{key}: {value}")
+    template_text = "\n".join(template_lines)
+
+    question_id = f"q_{uuid.uuid4().hex[:8]}"
+    prompt = f"{prompt_base}\n\nPlease reply with:\n{template_text}"
+    question = {
+        "id": question_id,
+        "kind": "missing_tool_fields",
+        "server_id": server_id,
+        "tool_name": tool_name,
+        "prompt": prompt,
+        "missing_fields": missing_fields,
+        "fields": fields,
+        "suggested_values": suggested_values,
+    }
+    pending = {
+        **question,
+        "arguments": pending_arguments,
+    }
+    return question, pending
+
+
+def extract_donation_updates_from_message(
+    message: str,
+    missing_fields: list[str],
+) -> dict[str, Any]:
+    """Best-effort extraction of donation field updates from user free text."""
+    text = (message or "").strip()
+    if not text:
+        return {}
+
+    payload = _parse_json_object(text)
+    if payload and isinstance(payload.get("donation_json"), dict):
+        payload = payload["donation_json"]
+
+    updates: dict[str, Any] = {}
+    if isinstance(payload, dict):
+        mapped_org = _sanitize_candidate(
+            _first_non_empty(
+                payload,
+                ("organization_name", "organization", "org_name", "charity_name", "charity", "recipient"),
+            )
+        )
+        if mapped_org is not None:
+            updates["organization_name"] = mapped_org
+        mapped_date = _sanitize_candidate(
+            _first_non_empty(
+                payload,
+                ("donation_date", "date", "donationDate", "service_date", "paid_date"),
+            )
+        )
+        if mapped_date is not None:
+            updates["donation_date"] = mapped_date
+        mapped_amount = _sanitize_candidate(_first_non_empty(payload, ("amount", "donation_amount", "total")))
+        if mapped_amount is not None:
+            updates["amount"] = mapped_amount
+
+        cash_candidate = _sanitize_candidate(
+            _first_non_empty(
+                payload,
+                (
+                    "cash_confirmation",
+                    "is_cash_donation",
+                    "cash_donation",
+                    "cash",
+                    "payment_method",
+                    "payment_type",
+                ),
+            )
+        )
+        if cash_candidate is not None:
+            cash_confirmation = _coerce_boolish(cash_candidate)
+            if cash_confirmation is not None:
+                updates["cash_confirmation"] = cash_confirmation
+        if "cash_confirmation" not in updates:
+            has_receipt = _sanitize_candidate(
+                _first_non_empty(payload, ("has_receipt", "receipt_available", "receipt_provided"))
+            )
+            receipt_bool = _coerce_boolish(has_receipt)
+            if receipt_bool is not None:
+                updates["cash_confirmation"] = not receipt_bool
+
+    if "organization_name" not in updates:
+        match = re.search(
+            r"(?:organization(?:\s+name)?|org(?:\s+name)?|charity|recipient)\s*[:=]\s*([^\n,;]+)",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if match:
+            org_candidate = _sanitize_candidate(match.group(1).strip())
+            if org_candidate is not None:
+                updates["organization_name"] = org_candidate
+
+    if "donation_date" not in updates:
+        match = re.search(
+            (
+                r"(?:donation\s+date|date)\s*[:=]\s*("
+                r"20\d{2}-\d{2}-\d{2}"
+                r"|\d{1,2}/\d{1,2}/20\d{2}"
+                r"|[A-Za-z]{3,9}\s+\d{1,2},\s*20\d{2}"
+                r")"
+            ),
+            text,
+            flags=re.IGNORECASE,
+        )
+        if match:
+            updates["donation_date"] = match.group(1).strip()
+        else:
+            iso_date = re.search(r"\b(20\d{2}-\d{2}-\d{2})\b", text)
+            slash_date = re.search(r"\b(\d{1,2}/\d{1,2}/20\d{2})\b", text)
+            if iso_date:
+                updates["donation_date"] = iso_date.group(1)
+            elif slash_date:
+                updates["donation_date"] = slash_date.group(1)
+
+    if "amount" not in updates:
+        match = re.search(
+            r"(?:amount|donation\s+amount|total)\s*[:=]\s*\$?\s*([0-9]+(?:,[0-9]{3})*(?:\.[0-9]+)?)",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if match:
+            updates["amount"] = match.group(1)
+        else:
+            standalone = re.search(r"\$\s*([0-9]+(?:,[0-9]{3})*(?:\.[0-9]+)?)", text)
+            if standalone:
+                updates["amount"] = standalone.group(1)
+
+    if "cash_confirmation" not in updates:
+        cash_labeled = re.search(
+            r"(?:cash(?:\s+donation)?|cash_confirmation|is_cash_donation)\s*[:=]\s*([^\n,;]+)",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if cash_labeled:
+            cash_value = _coerce_boolish(cash_labeled.group(1))
+            if cash_value is not None:
+                updates["cash_confirmation"] = cash_value
+        else:
+            receipt_labeled = re.search(
+                r"(?:has\s+receipt|receipt(?:\s+available|\s+provided)?)\s*[:=]\s*([^\n,;]+)",
+                text,
+                flags=re.IGNORECASE,
+            )
+            if receipt_labeled:
+                receipt_value = _coerce_boolish(receipt_labeled.group(1))
+                if receipt_value is not None:
+                    updates["cash_confirmation"] = not receipt_value
+
+    if (
+        "organization_name" not in updates
+        and len(missing_fields) == 1
+        and missing_fields[0] == "organization_name"
+    ):
+        looks_like_scalar = bool(
+            re.fullmatch(r"\$?\s*[0-9]+(?:\.[0-9]+)?", text)
+            or re.fullmatch(r"20\d{2}-\d{2}-\d{2}", text)
+            or re.fullmatch(r"\d{1,2}/\d{1,2}/20\d{2}", text)
+        )
+        if not looks_like_scalar and not text.startswith("{"):
+            updates["organization_name"] = text
+
+    if (
+        "cash_confirmation" not in updates
+        and len(missing_fields) == 1
+        and missing_fields[0] == "cash_confirmation"
+    ):
+        scalar_cash = _coerce_boolish(text)
+        if scalar_cash is not None:
+            updates["cash_confirmation"] = scalar_cash
+
+    return updates

--- a/apps/api/vivian_api/chat/session.py
+++ b/apps/api/vivian_api/chat/session.py
@@ -94,6 +94,8 @@ class SessionContext(BaseModel):
     last_intent: Optional[str] = None
     web_search_enabled: bool = False  # Web search costs ~$0.02/query, default OFF
     enabled_mcp_servers: List[str] = Field(default_factory=list)
+    # Pending structured follow-up question waiting for user input.
+    pending_user_question: Optional[Dict[str, Any]] = None
 
 
 class ErrorRecoveryState(BaseModel):

--- a/apps/api/vivian_api/services/mcp_registry.py
+++ b/apps/api/vivian_api/services/mcp_registry.py
@@ -121,6 +121,7 @@ def get_mcp_server_definitions(settings: Settings) -> dict[str, MCPServerDefinit
             tools=[
                 "upload_charitable_receipt_to_drive",
                 "append_charitable_donation_to_ledger",
+                "append_cash_charitable_donation_to_ledger",
                 "check_charitable_duplicates",
                 "get_charitable_summary",
                 "read_charitable_ledger_entries",

--- a/apps/mcp-server/tests/test_charitable_tools.py
+++ b/apps/mcp-server/tests/test_charitable_tools.py
@@ -1,0 +1,179 @@
+"""Unit tests for charitable donation normalization and validation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vivian_mcp.tools.charitable_tools import CharitableToolManager
+
+
+def test_normalize_donation_payload_accepts_aliases():
+    manager = CharitableToolManager()
+
+    normalized, missing_fields = manager._normalize_donation_payload(
+        {
+            "organization": " Luminary Coffee House ",
+            "date": "02/23/2026",
+            "amount": "$100.00",
+            "notes": "Cash donation to support local business",
+            "tax_deductible": "no",
+        }
+    )
+
+    assert missing_fields == []
+    assert normalized["organization_name"] == "Luminary Coffee House"
+    assert normalized["donation_date"] == "2026-02-23"
+    assert normalized["amount"] == 100.0
+    assert normalized["tax_deductible"] is False
+    assert normalized["description"] == "Cash donation to support local business"
+
+
+@pytest.mark.asyncio
+async def test_append_cash_donation_requires_org_and_date_and_cash_confirmation():
+    manager = CharitableToolManager()
+
+    result = json.loads(
+        await manager.append_cash_donation_to_ledger(
+            {
+                "amount": 100,
+            }
+        )
+    )
+
+    assert result["success"] is False
+    assert "organization_name" in result["missing_fields"]
+    assert "donation_date" in result["missing_fields"]
+    assert "cash_confirmation" in result["missing_fields"]
+    assert "Ask the user to provide" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_check_for_duplicates_requests_missing_fields_without_sheet_call(monkeypatch):
+    manager = CharitableToolManager()
+    called = False
+
+    async def fake_get_all_rows(**_kwargs):
+        nonlocal called
+        called = True
+        return {"success": True, "headers": [], "rows": []}
+
+    monkeypatch.setattr(manager, "get_all_rows", fake_get_all_rows)
+
+    result = await manager.check_for_duplicates(
+        {
+            "amount": 100,
+        }
+    )
+
+    assert called is False
+    assert result["recommendation"] == "needs_input"
+    assert "organization_name" in result["missing_fields"]
+    assert "donation_date" in result["missing_fields"]
+
+
+@pytest.mark.asyncio
+async def test_append_donation_to_ledger_normalizes_aliases(monkeypatch):
+    manager = CharitableToolManager()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(manager, "_resolve_spreadsheet", lambda: ("sheet_123", "Charitable Donations"))
+
+    async def fake_ensure_worksheet_exists(**_kwargs):
+        return {"success": True}
+
+    async def fake_check_for_duplicates(_donation_json, _fuzzy_days=3):
+        return {
+            "is_duplicate": False,
+            "potential_duplicates": [],
+            "recommendation": "import",
+        }
+
+    async def fake_append_row(**kwargs):
+        captured["row_data"] = kwargs["row_data"]
+        return {"success": True}
+
+    monkeypatch.setattr(manager, "ensure_worksheet_exists", fake_ensure_worksheet_exists)
+    monkeypatch.setattr(manager, "check_for_duplicates", fake_check_for_duplicates)
+    monkeypatch.setattr(manager, "append_row", fake_append_row)
+
+    result = json.loads(
+        await manager.append_donation_to_ledger(
+            {
+                "organization": "Luminary Coffee House",
+                "date": "02/23/2026",
+                "amount": "100",
+                "tax_deductible": "false",
+                "notes": "Support local business",
+            },
+            "cash_donation_no_receipt",
+        )
+    )
+
+    assert result["success"] is True
+    assert captured["row_data"][1] == "Luminary Coffee House"
+    assert captured["row_data"][2] == "2026-02-23"
+    assert captured["row_data"][3] == 100.0
+    assert captured["row_data"][4] == "No"
+    assert captured["row_data"][5] == "Support local business"
+
+
+@pytest.mark.asyncio
+async def test_append_cash_donation_rejects_when_not_confirmed_cash():
+    manager = CharitableToolManager()
+
+    result = json.loads(
+        await manager.append_cash_donation_to_ledger(
+            {
+                "organization_name": "Luminary Coffee House",
+                "donation_date": "2026-02-23",
+                "amount": 100,
+                "payment_method": "card",
+            }
+        )
+    )
+
+    assert result["success"] is False
+    assert result["recommended_action"] == "upload_receipt"
+    assert result["next_tool"] == "upload_charitable_receipt_to_drive"
+    assert "not confirmed as cash" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_append_cash_donation_accepts_confirmed_cash(monkeypatch):
+    manager = CharitableToolManager()
+    captured: dict[str, object] = {}
+
+    async def fake_append_donation_to_ledger(
+        donation_json,
+        drive_file_id,
+        check_duplicates=True,
+        force_append=False,
+    ):
+        captured["donation_json"] = donation_json
+        captured["drive_file_id"] = drive_file_id
+        captured["check_duplicates"] = check_duplicates
+        captured["force_append"] = force_append
+        return json.dumps({"success": True, "entry_id": "cash123", "tax_year": "2026"})
+
+    monkeypatch.setattr(manager, "append_donation_to_ledger", fake_append_donation_to_ledger)
+
+    result = json.loads(
+        await manager.append_cash_donation_to_ledger(
+            {
+                "organization": "Luminary Coffee House",
+                "date": "02/23/2026",
+                "amount": "100",
+                "cash_confirmation": "yes",
+            },
+            check_duplicates=False,
+            force_append=True,
+        )
+    )
+
+    assert result["success"] is True
+    assert captured["drive_file_id"] == "cash_donation_no_receipt"
+    assert captured["check_duplicates"] is False
+    assert captured["force_append"] is True
+    assert captured["donation_json"]["is_cash_donation"] is True

--- a/apps/mcp-server/vivian_mcp/contracts.py
+++ b/apps/mcp-server/vivian_mcp/contracts.py
@@ -248,6 +248,19 @@ class AppendCharitableDonationOutput(ToolOutputModel):
     error: str | None = None
 
 
+class AppendCashCharitableDonationInput(ToolInputModel):
+    donation_json: dict[str, Any]
+    check_duplicates: bool = True
+    force_append: bool = False
+
+
+class AppendCashCharitableDonationOutput(ToolOutputModel):
+    success: bool
+    entry_id: str | None = None
+    tax_year: str | None = None
+    duplicate_check: dict[str, Any] | None = None
+    error: str | None = None
+
 class CharitableDuplicateMatch(ToolOutputModel):
     organization: str = ""
     date: str = ""
@@ -422,6 +435,13 @@ TOOL_CONTRACTS: tuple[MCPToolContract, ...] = (
         description="Add a charitable donation to the Google Sheets ledger",
         input_model=AppendCharitableDonationInput,
         output_model=AppendCharitableDonationOutput,
+    ),
+
+    MCPToolContract(
+        name="append_cash_charitable_donation_to_ledger",
+        description="Add a cash charitable donation directly to the Google Sheets ledger without a receipt upload",
+        input_model=AppendCashCharitableDonationInput,
+        output_model=AppendCashCharitableDonationOutput,
     ),
     MCPToolContract(
         name="check_charitable_duplicates",

--- a/apps/mcp-server/vivian_mcp/contracts.py
+++ b/apps/mcp-server/vivian_mcp/contracts.py
@@ -435,6 +435,8 @@ TOOL_CONTRACTS: tuple[MCPToolContract, ...] = (
         description="Add a charitable donation to the Google Sheets ledger",
         input_model=AppendCharitableDonationInput,
         output_model=AppendCharitableDonationOutput,
+        server_id="charitable_ledger",
+        model_visible=True,
     ),
 
     MCPToolContract(
@@ -442,12 +444,16 @@ TOOL_CONTRACTS: tuple[MCPToolContract, ...] = (
         description="Add a cash charitable donation directly to the Google Sheets ledger without a receipt upload",
         input_model=AppendCashCharitableDonationInput,
         output_model=AppendCashCharitableDonationOutput,
+        server_id="charitable_ledger",
+        model_visible=True,
     ),
     MCPToolContract(
         name="check_charitable_duplicates",
         description="Check if a charitable donation is a duplicate of existing entries",
         input_model=CheckCharitableDuplicatesInput,
         output_model=CheckCharitableDuplicatesOutput,
+        server_id="charitable_ledger",
+        model_visible=True,
     ),
     MCPToolContract(
         name="get_charitable_summary",

--- a/apps/mcp-server/vivian_mcp/server.py
+++ b/apps/mcp-server/vivian_mcp/server.py
@@ -10,6 +10,7 @@ from mcp.server.fastmcp import FastMCP
 
 from vivian_mcp.config import Settings
 from vivian_mcp.contracts import (
+    AppendCashCharitableDonationOutput,
     AppendCharitableDonationOutput,
     AppendExpenseOutput,
     BulkImportFromDirectoryOutput,
@@ -144,6 +145,12 @@ async def _execute_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         raw_result = await charitable_tools.append_donation_to_ledger(
             arguments["donation_json"],
             arguments["drive_file_id"],
+            arguments.get("check_duplicates", True),
+            arguments.get("force_append", False),
+        )
+    elif name == "append_cash_charitable_donation_to_ledger":
+        raw_result = await charitable_tools.append_cash_donation_to_ledger(
+            arguments["donation_json"],
             arguments.get("check_duplicates", True),
             arguments.get("force_append", False),
         )
@@ -343,6 +350,24 @@ async def append_charitable_donation_to_ledger(
         AppendCharitableDonationOutput,
         donation_json=donation_json,
         drive_file_id=drive_file_id,
+        check_duplicates=check_duplicates,
+        force_append=force_append,
+    )
+
+
+@app.tool(
+    name="append_cash_charitable_donation_to_ledger",
+    description=_contract_description("append_cash_charitable_donation_to_ledger"),
+)
+async def append_cash_charitable_donation_to_ledger(
+    donation_json: dict[str, Any],
+    check_duplicates: bool = True,
+    force_append: bool = False,
+) -> AppendCashCharitableDonationOutput:
+    return await _run_tool(
+        "append_cash_charitable_donation_to_ledger",
+        AppendCashCharitableDonationOutput,
+        donation_json=donation_json,
         check_duplicates=check_duplicates,
         force_append=force_append,
     )


### PR DESCRIPTION
### Motivation
- Allow recording charitable gifts made in cash (no Drive receipt) while keeping the existing charitable ledger schema and workflows intact.  
- Provide an MCP-server-level tool so callers can add cash donations without requiring a Drive upload or changing client behavior.  
- Reuse existing validation/duplicate-checking and Google Sheets append logic to avoid duplicating ledger code.

### Description
- Add `AppendCashCharitableDonationInput` and `AppendCashCharitableDonationOutput` models and register a new `MCPToolContract` named `append_cash_charitable_donation_to_ledger` in `apps/mcp-server/vivian_mcp/contracts.py`.  
- Wire server dispatch and FastMCP tool registration for `append_cash_charitable_donation_to_ledger` in `apps/mcp-server/vivian_mcp/server.py` so the tool can be invoked without a `drive_file_id`.  
- Implement `CharitableToolManager.append_cash_donation_to_ledger(...)` and add a `CASH_DONATION_DRIVE_FILE_ID` sentinel in `apps/mcp-server/vivian_mcp/tools/charitable_tools.py`, which defaults a missing description to `"Cash donation"` and reuses `append_donation_to_ledger(...)` to perform the sheet append.  
- Add FastMCP wiring tests in `apps/mcp-server/tests/test_fastmcp_server.py` to verify the tool is registered and that calls route to the manager with the expected arguments.

### Testing
- Ran `python -m py_compile` on the modified modules (`contracts.py`, `server.py`, `charitable_tools.py`, and the updated test file`) and compilation completed without syntax errors.  
- Executed `pytest apps/mcp-server/tests/test_fastmcp_server.py -q` in this environment but test collection failed with `ModuleNotFoundError: No module named 'mcp'`, so full test execution could not be completed here.  
- FastMCP wiring tests were added to exercise registration and routing; they will run in CI or a developer environment that provides the `mcp` dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953d2e21c88320a80079d52f58c499)