### PR TITLE
Runtime Ollama model discovery: config, router and LLM updates + tests

### DIFF
--- a/apps/api/tests/test_ollama_models.py
+++ b/apps/api/tests/test_ollama_models.py
@@ -1,0 +1,70 @@
+"""Tests for runtime Ollama model discovery."""
+
+import asyncio
+import sys
+import types
+
+
+# Stub httpx before importing config to avoid dependency on external package.
+httpx_module = types.ModuleType("httpx")
+httpx_module.AsyncClient = object
+sys.modules.setdefault("httpx", httpx_module)
+
+from vivian_api import config
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get(self, _url: str, timeout: float = 0):
+        return self._response
+
+
+def test_get_ollama_models_reads_tags(monkeypatch):
+    response = _FakeResponse(
+        200,
+        {
+            "models": [
+                {"name": "llama3.2:3b"},
+                {"name": "qwen2.5:latest"},
+                {"missing": "ignored"},
+            ]
+        },
+    )
+
+    monkeypatch.setattr(config.httpx, "AsyncClient", lambda: _FakeAsyncClient(response))
+
+    models = asyncio.run(config.get_ollama_models())
+
+    assert models == [
+        {"id": "ollama/llama3.2:3b", "name": "llama3.2:3b", "provider": "Ollama"},
+        {"id": "ollama/qwen2.5:latest", "name": "qwen2.5:latest", "provider": "Ollama"},
+    ]
+
+
+def test_get_available_models_includes_runtime_ollama(monkeypatch):
+    async def fake_get_ollama_models():
+        return [{"id": "ollama/test-model", "name": "test-model", "provider": "Ollama"}]
+
+    monkeypatch.setattr(config, "get_ollama_models", fake_get_ollama_models)
+
+    models = asyncio.run(config.get_available_models())
+
+    assert any(model["id"] == "ollama/test-model" for model in models)
+    assert any(model["provider"] == "OpenRouter" for model in models)

--- a/apps/api/vivian_api/chat/router.py
+++ b/apps/api/vivian_api/chat/router.py
@@ -34,6 +34,7 @@ from vivian_api.services.llm import (
 )
 from vivian_api.config import (
     AVAILABLE_MODELS,
+    get_available_models,
     DEFAULT_MODEL,
     Settings,
     check_ollama_status,
@@ -1522,7 +1523,8 @@ async def list_models(
     }
     
     models_with_status = []
-    for model in AVAILABLE_MODELS:
+    all_models = await get_available_models()
+    for model in all_models:
         model_info = {
             "id": model["id"],
             "name": model["name"],
@@ -1548,14 +1550,15 @@ async def select_model(
     """Change the active model (in-memory)."""
     ollama_status = await check_ollama_status()
     
-    valid_ids = [m["id"] for m in AVAILABLE_MODELS]
+    all_models = await get_available_models()
+    valid_ids = [m["id"] for m in all_models]
     if request.model_id not in valid_ids:
         raise HTTPException(
             status_code=400,
             detail=f"Invalid model ID. Available: {valid_ids}"
         )
     
-    model = next((m for m in AVAILABLE_MODELS if m["id"] == request.model_id), None)
+    model = next((m for m in all_models if m["id"] == request.model_id), None)
     if model and model["provider"] == "Ollama" and not ollama_status.get("available", False):
         raise HTTPException(
             status_code=503,

--- a/apps/api/vivian_api/config.py
+++ b/apps/api/vivian_api/config.py
@@ -22,42 +22,6 @@ AVAILABLE_MODELS = [
     {"id": "anthropic/claude-3.5-sonnet", "name": "Claude 3.5 Sonnet", "provider": "OpenRouter"},
     {"id": "mistralai/mistral-large-2512", "name": "Mistral Large (Latest)", "provider": "OpenRouter"},
     {"id": "mistralai/devstral-2512", "name": "Devstral 2", "provider": "OpenRouter"},
-    # Ollama models (local, not via OpenRouter)
-    {
-        "id": "qwen2.5-coder:3b",
-        "name": "Qwen2.5 Coder 3B",
-        "provider": "Ollama"
-    },
-    {
-        "id": "mistral:7b-instruct",
-        "name": "Mistral 7B Instruct",
-        "provider": "Ollama"
-    },
-    {
-        "id": "mistral:7b",
-        "name": "Mistral 7B",
-        "provider": "Ollama"
-    },
-    {
-        "id": "llama3.1:8b",
-        "name": "Llama 3.1 8B",
-        "provider": "Ollama"
-    },
-    {
-        "id": "llama3.2:3b",
-        "name": "Llama 3.2 3B",
-        "provider": "Ollama"
-    },
-    {
-        "id": "qwen2.5:1.5b",
-        "name": "Qwen 2.5 1.5B",
-        "provider": "Ollama"
-    },
-    {
-        "id": "deepseek-coder:1.3b",
-        "name": "DeepSeek Coder 1.3B",
-        "provider": "Ollama"
-    }
 ]
 
 DEFAULT_MODEL = "google/gemini-3-flash-preview"
@@ -225,6 +189,46 @@ async def check_ollama_status() -> dict:
             return {"status": "error", "available": False}
     except Exception:
         return {"status": "offline", "available": False}
+
+
+async def get_ollama_models() -> list[dict[str, str]]:
+    """Get available local Ollama models from the Ollama API."""
+    ollama_url = get_ollama_base_url()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{ollama_url}/api/tags", timeout=3.0)
+            if response.status_code != 200:
+                return []
+
+            payload = response.json()
+            models = payload.get("models", [])
+            if not isinstance(models, list):
+                return []
+
+            available_models: list[dict[str, str]] = []
+            for model in models:
+                if not isinstance(model, dict):
+                    continue
+                name = model.get("name")
+                if not isinstance(name, str) or not name.strip():
+                    continue
+                model_name = name.strip()
+                available_models.append(
+                    {
+                        "id": f"ollama/{model_name}",
+                        "name": model_name,
+                        "provider": "Ollama",
+                    }
+                )
+
+            return available_models
+    except Exception:
+        return []
+
+
+async def get_available_models() -> list[dict[str, object]]:
+    """Return all selectable models including runtime Ollama models."""
+    return [*AVAILABLE_MODELS, *(await get_ollama_models())]
 
 
 settings = Settings()

--- a/apps/api/vivian_api/services/llm.py
+++ b/apps/api/vivian_api/services/llm.py
@@ -9,15 +9,18 @@ from typing import Any
 
 import httpx
 
-from vivian_api.config import Settings, get_selected_model, AVAILABLE_MODELS, get_ollama_base_url
+from vivian_api.config import Settings, get_selected_model, get_available_models, get_ollama_base_url
 
 
 logger = logging.getLogger(__name__)
 
 
-def _is_ollama_model(model_id: str) -> bool:
+async def _is_ollama_model(model_id: str) -> bool:
     """Check if a model ID corresponds to an Ollama model."""
-    for model in AVAILABLE_MODELS:
+    if model_id.startswith("ollama/"):
+        return True
+
+    for model in await get_available_models():
         if model["id"] == model_id:
             return model.get("provider") == "Ollama"
     return False
@@ -189,7 +192,7 @@ async def get_chat_completion_result(
 ) -> ChatCompletionResult:
     """Get completion text plus optional tool calls for model-driven function execution."""
     model = get_selected_model()
-    if _is_ollama_model(model):
+    if await _is_ollama_model(model):
         if tools:
             logger.warning(
                 "llm.tools_requested_with_ollama model=%s tools=%s",


### PR DESCRIPTION
### Motivation

- Enable discovery of locally hosted Ollama models at runtime instead of shipping static Ollama entries in the hard-coded model list.
- Ensure model listing and selection endpoints reflect runtime Ollama availability and prevent selecting Ollama models when Ollama is offline.
- Make LLM routing logic correctly detect Ollama models from the dynamic model list.

### Description

- Added `get_ollama_models()` and `get_available_models()` to `vivian_api.config` to query the Ollama API (`/api/tags`) and merge runtime Ollama models with the static `AVAILABLE_MODELS` list.
- Removed hard-coded Ollama model entries from `AVAILABLE_MODELS` so Ollama models are discovered at runtime only.
- Updated the chat router (`/models` and `/models/select`) to call `get_available_models()` and to mark Ollama models as selectable only when `check_ollama_status()` reports Ollama as available.
- Changed `_is_ollama_model` in `vivian_api.services.llm` to be asynchronous and to consult `get_available_models()` (and treat IDs starting with `ollama/` as Ollama models), and updated callers to `await` it.
- Added unit tests `apps/api/tests/test_ollama_models.py` which stub `httpx` to validate `get_ollama_models()` parsing and that `get_available_models()` includes runtime Ollama models.

### Testing

- Ran the new test file with `pytest -q apps/api/tests/test_ollama_models.py` and it passed.
- Ran the affected unit tests under `apps/api` to validate router and LLM changes and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a66c9867588320a2a1ad86c27878c1)