### PR TITLE
Add home-scoped custom MCP server definitions persistence

### DIFF
--- a/apps/api/alembic/versions/0002_add_mcp_custom_server_definitions.py
+++ b/apps/api/alembic/versions/0002_add_mcp_custom_server_definitions.py
@@ -1,0 +1,75 @@
+"""Add per-home custom MCP server definitions.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-02-21 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_custom_server_definitions",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("home_id", postgresql.UUID(as_uuid=False), sa.ForeignKey("homes.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("server_id", sa.String(length=100), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("command_tokens", postgresql.JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column("server_path", sa.String(length=1024), nullable=True),
+        sa.Column("default_enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("source", sa.String(length=64), nullable=False),
+        sa.Column("created_by", postgresql.UUID(as_uuid=False), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("metadata_json", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.UniqueConstraint("home_id", "server_id", name="ix_mcp_custom_server_definitions_home_id_server_id"),
+    )
+    op.create_index(
+        "ix_mcp_custom_server_definitions_home_id",
+        "mcp_custom_server_definitions",
+        ["home_id"],
+        unique=False,
+    )
+
+    op.execute(
+        """
+        INSERT INTO mcp_custom_server_definitions (
+            home_id,
+            server_id,
+            name,
+            command_tokens,
+            default_enabled,
+            source,
+            created_at,
+            updated_at
+        )
+        SELECT DISTINCT
+            home_id,
+            mcp_server_id,
+            mcp_server_id,
+            '[]'::jsonb,
+            true,
+            'legacy',
+            NOW(),
+            NOW()
+        FROM mcp_server_settings
+        ON CONFLICT (home_id, server_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mcp_custom_server_definitions_home_id", table_name="mcp_custom_server_definitions")
+    op.drop_table("mcp_custom_server_definitions")

--- a/apps/api/tests/test_mcp_custom_server_definition_repository.py
+++ b/apps/api/tests/test_mcp_custom_server_definition_repository.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from vivian_api.db.database import Base
+from vivian_api.models.identity_models import Home, User
+from vivian_api.repositories.connection_repository import (
+    McpCustomServerDefinitionRepository,
+)
+
+
+def _build_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal()
+
+
+def test_mcp_custom_server_definition_crud_by_home() -> None:
+    db = _build_session()
+
+    home = Home(name="Home", timezone="UTC")
+    other_home = Home(name="Other", timezone="UTC")
+    user = User(email="creator@example.com", status="active")
+    db.add_all([home, other_home, user])
+    db.commit()
+    db.refresh(home)
+    db.refresh(other_home)
+    db.refresh(user)
+
+    repo = McpCustomServerDefinitionRepository(db)
+
+    created = repo.create(
+        home_id=home.id,
+        server_id="custom_alpha",
+        name="Custom Alpha",
+        description="First custom MCP",
+        command_tokens=["python", "-m", "alpha"],
+        server_path="/tmp/alpha",
+        default_enabled=True,
+        source="custom",
+        created_by=user.id,
+        metadata_json={"team": "qa"},
+    )
+
+    fetched = repo.get_by_home_and_server(home.id, "custom_alpha")
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.command_tokens == ["python", "-m", "alpha"]
+
+    assert repo.get_by_home_and_server(other_home.id, "custom_alpha") is None
+
+    updated = repo.update(
+        created,
+        name="Custom Alpha Updated",
+        command_tokens=["uvx", "alpha"],
+        default_enabled=False,
+        metadata_json={"team": "platform"},
+    )
+    assert updated.name == "Custom Alpha Updated"
+    assert updated.command_tokens == ["uvx", "alpha"]
+    assert updated.default_enabled is False
+    assert updated.metadata_json == {"team": "platform"}
+
+    listed = repo.list_by_home(home.id)
+    assert len(listed) == 1
+    assert listed[0].server_id == "custom_alpha"
+
+    repo.delete(updated)
+    assert repo.list_by_home(home.id) == []
+
+    db.close()

--- a/apps/api/vivian_api/models/__init__.py
+++ b/apps/api/vivian_api/models/__init__.py
@@ -1,7 +1,11 @@
 """ORM models exported for metadata registration and shared imports."""
 
 from vivian_api.models.chat_models import Chat, ChatMessage
-from vivian_api.models.connection_models import HomeConnection, McpServerSettings
+from vivian_api.models.connection_models import (
+    HomeConnection,
+    McpCustomServerDefinition,
+    McpServerSettings,
+)
 from vivian_api.models.identity_models import AuthSession, Client, Home, HomeMembership, User
 
 __all__ = [
@@ -14,4 +18,5 @@ __all__ = [
     "AuthSession",
     "HomeConnection",
     "McpServerSettings",
+    "McpCustomServerDefinition",
 ]

--- a/apps/api/vivian_api/models/connection_models.py
+++ b/apps/api/vivian_api/models/connection_models.py
@@ -7,6 +7,7 @@ from typing import Any
 import uuid
 
 from sqlalchemy import (
+    Boolean,
     DateTime,
     ForeignKey,
     Index,
@@ -123,3 +124,62 @@ class McpServerSettings(Base):
     )
 
     home: Mapped["Home"] = relationship("Home", back_populates="mcp_settings")
+
+
+class McpCustomServerDefinition(Base):
+    """Per-home MCP server definitions that can be customized by users."""
+
+    __tablename__ = "mcp_custom_server_definitions"
+    __table_args__ = (
+        Index(
+            "ix_mcp_custom_server_definitions_home_id_server_id",
+            "home_id",
+            "server_id",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    home_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("homes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    server_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    command_tokens: Mapped[list[str]] = mapped_column(
+        JSONB().with_variant(JSON, "sqlite"),
+        server_default=text("'[]'"),
+        nullable=False,
+    )
+    server_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    default_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("true"),
+    )
+    source: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_by: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB().with_variant(JSON, "sqlite"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("NOW()"), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("NOW()"),
+        onupdate=text("NOW()"),
+        nullable=False,
+    )
+
+    home: Mapped["Home"] = relationship("Home", back_populates="mcp_custom_server_definitions")

--- a/apps/api/vivian_api/models/identity_models.py
+++ b/apps/api/vivian_api/models/identity_models.py
@@ -54,6 +54,10 @@ class Home(Base):
         back_populates="home",
         cascade="all, delete-orphan",
     )
+    mcp_custom_server_definitions: Mapped[list["McpCustomServerDefinition"]] = relationship(
+        back_populates="home",
+        cascade="all, delete-orphan",
+    )
 
 
 class User(Base):

--- a/apps/api/vivian_api/repositories/__init__.py
+++ b/apps/api/vivian_api/repositories/__init__.py
@@ -6,6 +6,7 @@ from vivian_api.repositories.chat_repository import (
 )
 from vivian_api.repositories.connection_repository import (
     HomeConnectionRepository,
+    McpCustomServerDefinitionRepository,
     McpServerSettingsRepository,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "ChatRepository",
     "ChatMessageRepository",
     "HomeConnectionRepository",
+    "McpCustomServerDefinitionRepository",
     "McpServerSettingsRepository",
 ]

--- a/apps/api/vivian_api/repositories/connection_repository.py
+++ b/apps/api/vivian_api/repositories/connection_repository.py
@@ -9,7 +9,11 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from vivian_api.models.connection_models import HomeConnection, McpServerSettings
+from vivian_api.models.connection_models import (
+    HomeConnection,
+    McpCustomServerDefinition,
+    McpServerSettings,
+)
 from vivian_api.services.encryption import encryption_service
 
 
@@ -174,4 +178,104 @@ class McpServerSettingsRepository:
     def delete(self, settings: McpServerSettings) -> None:
         """Delete MCP server settings."""
         self.db.delete(settings)
+        self.db.commit()
+
+
+class McpCustomServerDefinitionRepository:
+    """Repository for per-home custom MCP server definitions."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def list_by_home(self, home_id: str) -> list[McpCustomServerDefinition]:
+        """List all custom MCP server definitions for a home."""
+        stmt = (
+            select(McpCustomServerDefinition)
+            .where(McpCustomServerDefinition.home_id == home_id)
+            .order_by(McpCustomServerDefinition.created_at.asc())
+        )
+        return list(self.db.scalars(stmt).all())
+
+    def get_by_home_and_server(
+        self,
+        home_id: str,
+        server_id: str,
+    ) -> McpCustomServerDefinition | None:
+        """Get a custom definition by home and server id."""
+        stmt = select(McpCustomServerDefinition).where(
+            McpCustomServerDefinition.home_id == home_id,
+            McpCustomServerDefinition.server_id == server_id,
+        )
+        return self.db.scalar(stmt)
+
+    def create(
+        self,
+        *,
+        home_id: str,
+        server_id: str,
+        name: str,
+        description: str | None = None,
+        command_tokens: list[str] | None = None,
+        server_path: str | None = None,
+        default_enabled: bool = True,
+        source: str,
+        created_by: str | None = None,
+        metadata_json: dict[str, Any] | None = None,
+    ) -> McpCustomServerDefinition:
+        """Create a new custom MCP server definition."""
+        definition = McpCustomServerDefinition(
+            id=str(uuid.uuid4()),
+            home_id=home_id,
+            server_id=server_id,
+            name=name,
+            description=description,
+            command_tokens=command_tokens or [],
+            server_path=server_path,
+            default_enabled=default_enabled,
+            source=source,
+            created_by=created_by,
+            metadata_json=metadata_json,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        self.db.add(definition)
+        self.db.commit()
+        self.db.refresh(definition)
+        return definition
+
+    def update(
+        self,
+        definition: McpCustomServerDefinition,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        command_tokens: list[str] | None = None,
+        server_path: str | None = None,
+        default_enabled: bool | None = None,
+        source: str | None = None,
+        metadata_json: dict[str, Any] | None = None,
+    ) -> McpCustomServerDefinition:
+        """Update an existing custom MCP server definition."""
+        if name is not None:
+            definition.name = name
+        if description is not None:
+            definition.description = description
+        if command_tokens is not None:
+            definition.command_tokens = command_tokens
+        if server_path is not None:
+            definition.server_path = server_path
+        if default_enabled is not None:
+            definition.default_enabled = default_enabled
+        if source is not None:
+            definition.source = source
+        if metadata_json is not None:
+            definition.metadata_json = metadata_json
+        definition.updated_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(definition)
+        return definition
+
+    def delete(self, definition: McpCustomServerDefinition) -> None:
+        """Delete a custom MCP server definition."""
+        self.db.delete(definition)
         self.db.commit()


### PR DESCRIPTION
### Motivation
- Introduce a first-class, per-home store for customizable MCP server definitions so homes can register custom MCP servers alongside the existing `mcp_server_settings` records. 
- Preserve existing per-server settings while aligning legacy `mcp_server_settings` entries with the new definitions to avoid behavioral regression.

### Description
- Add `McpCustomServerDefinition` ORM model in `apps/api/vivian_api/models/connection_models.py` keyed by `(home_id, server_id)` and including `name`, `description`, `command_tokens` (JSON array), `server_path`, `default_enabled`, `source`, `created_by`, `created_at`, `updated_at`, and optional `metadata_json` fields, plus a `Home` relationship. 
- Add Alembic migration `apps/api/alembic/versions/0002_add_mcp_custom_server_definitions.py` to create the `mcp_custom_server_definitions` table with a unique `(home_id, server_id)` constraint and backfill distinct legacy `mcp_server_settings` entries as `'legacy'` definitions. 
- Implement `McpCustomServerDefinitionRepository` in `apps/api/vivian_api/repositories/connection_repository.py` with `list_by_home`, `get_by_home_and_server`, `create`, `update`, and `delete` methods. 
- Wire model and repository exports and `Home` relationship by updating `apps/api/vivian_api/models/__init__.py`, `apps/api/vivian_api/repositories/__init__.py`, and `apps/api/vivian_api/models/identity_models.py`, and add repository CRUD tests in `apps/api/tests/test_mcp_custom_server_definition_repository.py`.

### Testing
- Ran `python -m py_compile` against the changed modules (`apps/api/vivian_api/models/connection_models.py`, `apps/api/vivian_api/models/identity_models.py`, `apps/api/vivian_api/repositories/connection_repository.py`, the new migration, and the new test) which succeeded. 
- Added a unit test `apps/api/tests/test_mcp_custom_server_definition_repository.py` that exercises create/read/update/list/delete flows for a home-scoped definition. 
- Attempted `pytest -q apps/api/tests/test_mcp_custom_server_definition_repository.py` in this environment but test collection failed with `ModuleNotFoundError: No module named 'sqlalchemy'`, so the repository test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999465041008320b969518a62ee7d1a)