### PR TITLE
feat(epic-0): API keys, internal token endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,44 +30,33 @@ Primary shared rule files:
 
 ### Python Environment
 
-This project uses **venv** (not uv). The virtual environment is at `.venv/` in the repo root.
+This project uses **uv** (not venv) for dependency management.
 
-**Activate venv:**
+**Run tests:**
 ```bash
-source .venv/bin/activate
+uv run --project apps/api --extra test pytest apps/api/tests
+```
+
+**Run MCP server tests:**
+```bash
+uv run --project apps/test-mcp-server --extra test pytest apps/test-mcp-server/tests
 ```
 
 ### Database Migrations
 
-**After merging feature branches with DB changes:**
+**Run migrations:**
+```bash
+cd apps/api && DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" uv run alembic upgrade head
+```
 
-1. **Check if migrations are pending:**
-   ```bash
-   cd apps/api
-   source ../../.venv/bin/activate
-   alembic current  # Shows current version
-   alembic heads    # Shows latest available version
-   ```
-
-2. **Run migrations:**
-   ```bash
-   DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" alembic upgrade head
-   ```
-
-3. **Restart the backend container** to load new code:
-   ```bash
-   docker compose restart api
-   ```
-
-**Common migration issues:**
-- Duplicate index errors: Don't use `index=True` on Column AND `op.create_index()` - choose one
-- "Failed to load" errors in frontend usually mean migrations haven't been run
-- The backend container runs migrations on startup, but doesn't auto-migrate when code changes
+**Check status:**
+```bash
+cd apps/api && DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" uv run alembic current
+```
 
 ### Container Management
 
-**The backend container does NOT auto-reload when you merge branches.** Always restart after merging:
-
+**Restart API container after code changes:**
 ```bash
 docker compose restart api
 docker logs vivian-backend-api-1 --tail 20  # Verify startup
@@ -75,10 +64,6 @@ docker logs vivian-backend-api-1 --tail 20  # Verify startup
 
 ## Code Review Policy
 
-Agents may push to feature branches and open pull requests without explicit approval when all of the following are true:
-
-- The agent is confident the change is correct.
-- Relevant tests/checks pass (or the best available checks pass when full test execution is unavailable).
-- Behavior has been verified to the best available degree (manual/API validation as appropriate).
+**Always ask for user approval before committing or opening a PR.** Do not push or open PRs without explicit approval.
 
 If confidence is low, validation is incomplete, or important checks fail, pause and ask for user guidance before pushing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,11 @@ For new `vivian-backend` worktrees, ensure `.env` exists before running Docker o
 
 **Always ask the user for approval before committing or opening a PR.** Do not commit or push without explicit approval.
 
+Before committing, check the current branch:
+- If on `main` (or `master`): pull latest (`git pull`) then create a new feature branch. Never commit directly to main.
+- If on a feature branch whose name doesn't match the current task: ask the user which branch to use before proceeding.
+- Do not reuse an existing feature branch for unrelated work.
+
 ---
 
 ## Link Settings API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,158 @@ FastAPI backend for the Vivian household agent. PostgreSQL in production, SQLite
 
 ---
 
+## Shared Rules
+
+### GitHub Issue Feature Workflow
+
+When implementing a new feature, especially work that originates from a GitHub issue:
+
+- Create and use a dedicated branch before making changes.
+- Name the branch so it is clearly tied to the issue and feature.
+- Prefer branch format: `<agent-or-developer-name>-<issue-number>-<short-feature-slug>` (example: `codex-123-google-integration`)
+- Do not implement feature work directly on long-lived branches (`main`, `master`).
+- After implementation, **always ask the user for approval before committing and opening a PR**.
+- In the PR description, include a closing keyword with the issue number so GitHub auto-closes it on merge:
+  - `Closes #<issue-number>` or `Fixes #<issue-number>`.
+- If no issue exists yet, create/link one before merge when the work is feature-sized.
+
+### GitHub Issue Management
+
+When creating GitHub issues, use the `gh` CLI:
+
+```bash
+gh issue create --title "Issue Title" --body-file /path/to/body.md --label "enhancement"
+# Or inline:
+gh issue create --title "Issue Title" --body "Issue description here"
+```
+
+Issue body structure for features: **Problem**, **Proposed Solution**, **Implementation Considerations**, **Benefits**.
+Issue body structure for bugs: **Describe the bug**, **To Reproduce**, **Expected behavior**, **Additional context**.
+
+Check available labels with: `gh label list`
+
+### Docker Compose: Run in Foreground
+
+When suggesting `docker compose up`, **do not use `-d`**.
+
+- Use: `docker compose up api` (or `docker compose up` for all services)
+- Avoid: `docker compose up -d api`
+
+### Debugging: Check Logs First
+
+When investigating errors, always check logs across the full stack first.
+
+```bash
+# Backend API (Docker)
+docker logs vivian-backend-api-1 --since 5m
+docker logs vivian-backend-api-1 2>&1 | grep -B5 -A10 "Error\|Traceback\|500\|exception"
+docker logs -f vivian-backend-api-1
+
+# PostgreSQL
+docker logs vivian-backend-postgres-1 --since 5m
+```
+
+Common pitfalls: stale containers after code changes, env var prefix `VIVIAN_API_`, Next.js caching.
+
+### Use Shared Helper Functions
+
+When writing code involving text normalization, date parsing, or common string operations, use shared helpers from `vivian_shared.helpers`:
+
+```python
+from vivian_shared.helpers import normalize_provider, normalize_title, normalize_header
+from vivian_shared.helpers import parse_date, days_between, is_within_days
+```
+
+Related files:
+- `packages/shared/src/vivian_shared/helpers/normalization.py`
+- `packages/shared/src/vivian_shared/helpers/dates.py`
+
+---
+
+## Development Workflow
+
+### Python Environment
+
+This project uses **uv** for dependency management (not venv).
+
+**Run tests:**
+```bash
+uv run --project apps/api --extra test pytest apps/api/tests
+```
+
+**Run MCP server tests:**
+```bash
+uv run --project apps/test-mcp-server --extra test pytest apps/test-mcp-server/tests
+```
+
+### Database Migrations
+
+The project uses Alembic for database schema management.
+
+**Run pending migrations:**
+```bash
+cd apps/api && DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" uv run alembic upgrade head
+```
+
+**Check current migration version:**
+```bash
+cd apps/api && DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" uv run alembic current
+```
+
+**Important notes:**
+- The backend container automatically runs migrations on startup via the entrypoint script.
+- When developing locally and pulling new branches, you may need to run migrations manually.
+- In `.env`, the database hostname is `postgres:5432` (for container-to-container communication).
+
+### After Merging New Code
+
+When you merge a feature branch that includes new API endpoints or database changes:
+
+1. **Run database migrations** (if schema changed):
+   ```bash
+   cd apps/api && DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" uv run alembic upgrade head
+   ```
+
+2. **Restart the backend container** to pick up new code:
+   ```bash
+   docker compose restart api
+   ```
+
+3. **Verify the endpoint** is working:
+   ```bash
+   docker logs vivian-backend-api-1 --tail 20
+   ```
+
+### Common Issues
+
+#### "Failed to load" errors in frontend
+- Usually means the backend database hasn't been migrated yet.
+- Run `alembic upgrade head` to apply pending migrations.
+
+#### Duplicate table/index errors in migrations
+- Don't use `index=True` on Column AND `op.create_index()` for the same column — choose one.
+
+#### Backend container has stale code
+- Always restart the API container after merging: `docker compose restart api`
+
+---
+
+## Worktree Env Setup
+
+For new `vivian-backend` worktrees, ensure `.env` exists before running Docker or API tests.
+
+- Canonical source env file: `/Users/Andrew/Developer/vivian-workspace/vivian-backend/.env`
+- Copy command: `cp /Users/Andrew/Developer/vivian-workspace/vivian-backend/.env <worktree-root>/.env`
+- Do not print or echo `.env` contents in logs or responses.
+
+---
+
+## Code Review Policy
+
+**Always ask the user for approval before committing or opening a PR.** Do not commit or push without explicit approval.
+
+---
+
 ## Link Settings API
 
 Link settings store the home server's base URL and per-app port numbers so the frontend can render quick-access links to self-hosted services (Jellyfin, Mealie, photo host, etc.).
@@ -45,194 +197,6 @@ All endpoints require a Bearer token:
 Authorization: Bearer <access_token>
 ```
 
----
-
-### Data Shape
-
-#### `LinkSetting` object
-
-```ts
-type LinkSetting = {
-  id: string           // UUID — stable row identifier
-  home_id: string      // UUID — the home this belongs to
-  key: string          // Slug: "server_url" | "jellyfin" | "mealie" | "images" | ...
-  label: string        // Display name shown in UI, e.g. "Jellyfin"
-  url: string | null   // Full URL — only set on the server_url entry (or direct links)
-  port: number | null  // Port number — set on app entries; null means link is hidden
-  icon: string | null  // Optional icon identifier or URL
-  created_at: string   // ISO 8601 datetime
-  updated_at: string   // ISO 8601 datetime
-}
-```
-
----
-
-### Endpoints
-
-#### List all link settings
-
-```
-GET /api/v1/link-settings
-```
-
-Returns all entries for the current home, sorted alphabetically by key.
-
-**Response `200`**
-```json
-[
-  {
-    "id": "...",
-    "home_id": "...",
-    "key": "jellyfin",
-    "label": "Jellyfin",
-    "url": null,
-    "port": 8096,
-    "icon": null,
-    "created_at": "2026-03-02T12:00:00",
-    "updated_at": "2026-03-02T12:00:00"
-  },
-  {
-    "key": "mealie",
-    "label": "Mealie",
-    "url": null,
-    "port": null,
-    "...": "..."
-  },
-  {
-    "key": "server_url",
-    "label": "Home Server",
-    "url": "http://192.168.1.10",
-    "port": null,
-    "...": "..."
-  }
-]
-```
-
----
-
-#### Create a link setting
-
-```
-POST /api/v1/link-settings
-```
-
-Provide `url` for the base server entry, or `port` for app entries.
-
-**Request body**
-```json
-{ "key": "jellyfin", "label": "Jellyfin", "port": 8096 }
-```
-```json
-{ "key": "server_url", "label": "Home Server", "url": "http://192.168.1.10" }
-```
-
-| Field   | Type           | Required | Notes                                   |
-|---------|----------------|----------|-----------------------------------------|
-| `key`   | string (≤100)  | Yes      | Must be unique per home                 |
-| `label` | string (≤255)  | Yes      | Display name                            |
-| `url`   | string \| null | No       | Full URL (for `server_url` key)         |
-| `port`  | int \| null    | No       | 1–65535 (for app keys like `jellyfin`)  |
-| `icon`  | string \| null | No       | Icon name or URL                        |
-
-**Response `201`** — the created `LinkSetting` object.
-**Error `409`** — key already exists for this home.
-
----
-
-#### Update a link setting
-
-```
-PUT /api/v1/link-settings/{key}
-```
-
-All body fields are optional; only provided fields are updated.
-
-**Response `200`** — updated `LinkSetting` object.
-**Error `404`** — key not found.
-
----
-
-#### Delete a link setting
-
-```
-DELETE /api/v1/link-settings/{key}
-```
-
-**Response `204`** — no body.
-**Error `404`** — key not found.
-
----
-
-### Frontend Integration Pattern
-
-#### 1. On settings load — fetch all link settings
-
-```ts
-const res = await fetch('/api/v1/link-settings', {
-  headers: { Authorization: `Bearer ${accessToken}` },
-});
-const settings: LinkSetting[] = await res.json();
-
-// Index by key for easy lookup
-const byKey = Object.fromEntries(settings.map(s => [s.key, s]));
-const serverUrl = byKey['server_url']?.url ?? '';
-```
-
-#### 2. Build a full URL from server + port
-
-```ts
-function buildUrl(serverUrl: string, port: number): string {
-  return `${serverUrl}:${port}`;
-}
-```
-
-#### 3. Render only configured links
-
-```ts
-const apps = [
-  { key: 'jellyfin', label: 'Jellyfin' },
-  { key: 'mealie',   label: 'Mealie'   },
-  { key: 'images',   label: 'Photos'   },
-];
-
-const visibleLinks = apps
-  .filter(app => byKey[app.key]?.port != null)
-  .map(app => ({
-    label: byKey[app.key].label,
-    url: buildUrl(serverUrl, byKey[app.key].port!),
-    icon: byKey[app.key].icon,
-  }));
-```
-
-#### 4. Settings form — save or update a port
-
-```ts
-// On first save (no entry yet)
-await fetch('/api/v1/link-settings', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-  body: JSON.stringify({ key: 'jellyfin', label: 'Jellyfin', port: 8096 }),
-});
-
-// On subsequent save (entry exists — PUT to the key)
-await fetch('/api/v1/link-settings/jellyfin', {
-  method: 'PUT',
-  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-  body: JSON.stringify({ port: 8920 }),
-});
-```
-
-#### 5. Clear a link (hide it from UI)
-
-```ts
-await fetch('/api/v1/link-settings/jellyfin', {
-  method: 'DELETE',
-  headers: { Authorization: `Bearer ${token}` },
-});
-```
-
----
-
 ### Well-known keys
 
 | Key          | Service               | Field to set |
@@ -241,88 +205,3 @@ await fetch('/api/v1/link-settings/jellyfin', {
 | `jellyfin`   | Jellyfin media server | `port`       |
 | `mealie`     | Mealie recipe manager | `port`       |
 | `images`     | Photo / image host    | `port`       |
-
-Any other key is valid — the list above is just convention.
-
----
-
-## Development Workflow
-
-### Python Environment
-
-This project uses a Python virtual environment (venv) located at `.venv/` in the repository root.
-
-**Activate the virtual environment:**
-```bash
-source .venv/bin/activate
-```
-
-### Database Migrations
-
-The project uses Alembic for database schema management.
-
-**Check current migration version:**
-```bash
-cd apps/api
-source ../../.venv/bin/activate
-alembic current
-```
-
-**Run pending migrations:**
-```bash
-cd apps/api
-source ../../.venv/bin/activate
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" alembic upgrade head
-```
-
-**Important notes:**
-- The backend container automatically runs migrations on startup via the entrypoint script
-- When developing locally and pulling new branches, you may need to run migrations manually
-- The `DATABASE_URL` environment variable defaults to `localhost:5432` which maps to the Docker postgres container
-- In `.env`, the database hostname is `postgres:5432` (for container-to-container communication)
-
-### After Merging New Code
-
-When you merge a feature branch that includes new API endpoints or database changes:
-
-1. **Run database migrations** (if schema changed):
-   ```bash
-   cd apps/api
-   source ../../.venv/bin/activate
-   DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" alembic upgrade head
-   ```
-
-2. **Restart the backend container** to pick up new code:
-   ```bash
-   docker compose restart api
-   ```
-
-3. **Verify the endpoint** is working:
-   ```bash
-   docker logs vivian-backend-api-1 --tail 20
-   ```
-
-### Common Issues
-
-#### "Failed to load" errors in frontend
-- Usually means the backend database hasn't been migrated yet
-- Check `alembic current` vs `alembic heads` to see if migrations are pending
-- Run `alembic upgrade head` to apply pending migrations
-
-#### Duplicate table/index errors in migrations
-- Alembic Column definitions with `index=True` automatically create indexes
-- Don't explicitly call `op.create_index()` for the same column - this creates a duplicate
-- **Example bug:**
-  ```python
-  # BAD - creates index twice
-  sa.Column("home_id", UUID, ForeignKey("homes.id"), index=True),  # Creates ix_table_home_id
-  op.create_index("ix_table_home_id", "table", ["home_id"])       # Duplicate!
-
-  # GOOD - only create once
-  sa.Column("home_id", UUID, ForeignKey("homes.id")),
-  op.create_index("ix_table_home_id", "table", ["home_id"])
-  ```
-
-#### Backend container has stale code
-- The container doesn't automatically reload when you merge branches
-- Always restart the API container after merging: `docker compose restart api`

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,37 @@
+# Vivian API — environment variable template
+# Copy to .env and fill in values before running.
+
+# Server
+VIVIAN_API_HOST=0.0.0.0
+VIVIAN_API_PORT=8000
+
+# Database
+VIVIAN_API_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/vivian
+
+# Authentication
+VIVIAN_API_AUTH_JWT_SECRET=change-me-in-production
+VIVIAN_API_AUTH_JWT_ALGORITHM=HS256
+VIVIAN_API_AUTH_ACCESS_TOKEN_MINUTES=15
+VIVIAN_API_AUTH_REFRESH_TOKEN_DAYS=30
+
+# Encryption key for sensitive data at rest (Fernet key)
+VIVIAN_API_ENCRYPTION_KEY=
+
+# Google OAuth
+VIVIAN_API_GOOGLE_CLIENT_ID=
+VIVIAN_API_GOOGLE_CLIENT_SECRET=
+VIVIAN_API_GOOGLE_OAUTH_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google/oauth/callback
+VIVIAN_API_GOOGLE_OAUTH_SUCCESS_REDIRECT=http://localhost:3000/settings?google=connected
+VIVIAN_API_GOOGLE_OAUTH_ERROR_REDIRECT=http://localhost:3000/settings?google=error
+
+# Vivian client URL (used in internal API error responses, e.g. google_not_connected)
+VIVIAN_API_VIVIAN_URL=http://localhost:3000
+
+# OpenRouter
+VIVIAN_API_OPENROUTER_API_KEY=
+
+# CORS
+# VIVIAN_API_CORS_ORIGINS=["http://localhost:3000","http://localhost:3001"]
+
+# Temp file storage
+VIVIAN_API_TEMP_UPLOAD_DIR=/tmp/vivian-uploads

--- a/apps/api/alembic/versions/0004_add_home_api_keys.py
+++ b/apps/api/alembic/versions/0004_add_home_api_keys.py
@@ -1,0 +1,59 @@
+"""Add home_api_keys table.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-03-11 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "home_api_keys",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=False),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "home_id",
+            sa.UUID(as_uuid=False),
+            sa.ForeignKey("homes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("key_hash", sa.String(128), nullable=False),
+        sa.Column("key_prefix", sa.String(20), nullable=False),
+        sa.Column(
+            "created_by",
+            sa.UUID(as_uuid=False),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_home_api_keys_home_id", "home_api_keys", ["home_id"])
+    op.create_index(
+        "ix_home_api_keys_key_hash", "home_api_keys", ["key_hash"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("home_api_keys")

--- a/apps/api/vivian_api/auth/dependencies.py
+++ b/apps/api/vivian_api/auth/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -12,7 +13,7 @@ from sqlalchemy.orm import Session, selectinload
 from vivian_api.auth.security import TokenExpiredError, TokenInvalidError, decode_access_token
 from vivian_api.config import Settings
 from vivian_api.db.database import get_db
-from vivian_api.models.identity_models import HomeMembership, User
+from vivian_api.models.identity_models import HomeApiKey, HomeMembership, User
 
 
 @dataclass(slots=True)
@@ -81,6 +82,36 @@ def get_current_user_context(
         memberships=memberships,
         default_membership=default_membership,
     )
+
+
+@dataclass(slots=True)
+class ApiKeyContext:
+    home_id: str
+    key_record: HomeApiKey
+
+
+def get_home_from_api_key(
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+    db: Session = Depends(get_db),
+) -> ApiKeyContext:
+    """Validate a home API key (viv_sk_...) and return its home context.
+
+    Updates last_used_at on every successful validation.
+    """
+    from vivian_api.repositories.api_key_repository import ApiKeyRepository
+
+    token = _extract_bearer_token(authorization)
+    if not token.startswith("viv_sk_"):
+        raise _unauthorized("Invalid API key format")
+
+    key_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    repo = ApiKeyRepository(db)
+    key_record = repo.get_by_hash(key_hash)
+    if not key_record:
+        raise HTTPException(status_code=401, detail="invalid_api_key")
+
+    repo.update_last_used(key_record)
+    return ApiKeyContext(home_id=str(key_record.home_id), key_record=key_record)
 
 
 def require_roles(*roles: str):

--- a/apps/api/vivian_api/auth/security.py
+++ b/apps/api/vivian_api/auth/security.py
@@ -73,6 +73,22 @@ def hash_refresh_token(refresh_token: str) -> str:
     return hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
 
 
+def generate_api_key() -> tuple[str, str, str]:
+    """Generate a new API key.
+
+    Returns:
+        (full_key, sha256_hash, prefix)
+        - full_key: the key to return to the user once (e.g. "viv_sk_<32 chars>")
+        - sha256_hash: stored in DB for lookup
+        - prefix: display-safe prefix shown in key list (e.g. "viv_sk_abcd1234")
+    """
+    random_part = secrets.token_urlsafe(32)[:32]
+    full_key = f"viv_sk_{random_part}"
+    key_hash = hashlib.sha256(full_key.encode("utf-8")).hexdigest()
+    prefix = f"viv_sk_{random_part[:8]}"
+    return full_key, key_hash, prefix
+
+
 def generate_refresh_token() -> str:
     return secrets.token_urlsafe(64)
 

--- a/apps/api/vivian_api/config.py
+++ b/apps/api/vivian_api/config.py
@@ -154,6 +154,9 @@ class Settings(BaseSettings):
     google_oauth_error_redirect: str = "http://localhost:3000/settings?google=error"
     # Note: token store path is now deprecated; tokens stored in DB
     google_oauth_token_store_path: str = "/tmp/vivian-uploads/google-oauth.json"
+
+    # Vivian client URL (used in internal API error responses)
+    vivian_url: str = "http://localhost:3000"
     class Config:
         env_file = ".env"
         env_prefix = "VIVIAN_API_"

--- a/apps/api/vivian_api/main.py
+++ b/apps/api/vivian_api/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from vivian_api.config import Settings
 from vivian_api.routers import receipts, ledger
-from vivian_api.routers import mcp, integrations, mcp_settings, link_settings
+from vivian_api.routers import mcp, integrations, mcp_settings, link_settings, api_keys, internal
 from vivian_api.chat import chat_router, history_router
 from vivian_api.auth.router import router as auth_router
 from vivian_api.models.schemas import HealthCheckResponse
@@ -63,6 +63,8 @@ app.include_router(chat_router, prefix="/api/v1")
 app.include_router(history_router, prefix="/api/v1")
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(link_settings.router, prefix="/api/v1")
+app.include_router(api_keys.router, prefix="/api/v1")
+app.include_router(internal.router, prefix="/api/v1")
 
 
 @app.get("/health", response_model=HealthCheckResponse)

--- a/apps/api/vivian_api/models/identity_models.py
+++ b/apps/api/vivian_api/models/identity_models.py
@@ -58,6 +58,10 @@ class Home(Base):
         back_populates="home",
         cascade="all, delete-orphan",
     )
+    api_keys: Mapped[list["HomeApiKey"]] = relationship(
+        back_populates="home",
+        cascade="all, delete-orphan",
+    )
 
 
 class User(Base):
@@ -194,3 +198,33 @@ class AuthSession(Base):
     )
 
     user: Mapped[User] = relationship(back_populates="auth_sessions")
+
+
+class HomeApiKey(Base):
+    """Named API key scoped to a home, used by the MCP server and other integrations."""
+
+    __tablename__ = "home_api_keys"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    home_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("homes.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    key_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    key_prefix: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_by: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("users.id"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    home: Mapped["Home"] = relationship("Home", back_populates="api_keys")
+    creator: Mapped["User | None"] = relationship("User", foreign_keys=[created_by])

--- a/apps/api/vivian_api/repositories/api_key_repository.py
+++ b/apps/api/vivian_api/repositories/api_key_repository.py
@@ -1,0 +1,69 @@
+"""Repository for HomeApiKey entities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from vivian_api.models.identity_models import HomeApiKey
+
+
+class ApiKeyRepository:
+    """Repository for HomeApiKey entities."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        *,
+        home_id: str,
+        name: str,
+        key_hash: str,
+        key_prefix: str,
+        created_by: str | None,
+    ) -> HomeApiKey:
+        key = HomeApiKey(
+            id=str(uuid.uuid4()),
+            home_id=home_id,
+            name=name,
+            key_hash=key_hash,
+            key_prefix=key_prefix,
+            created_by=created_by,
+            created_at=datetime.now(timezone.utc),
+            last_used_at=None,
+        )
+        self.db.add(key)
+        self.db.commit()
+        self.db.refresh(key)
+        return key
+
+    def list_by_home(self, home_id: str) -> list[HomeApiKey]:
+        stmt = (
+            select(HomeApiKey)
+            .where(HomeApiKey.home_id == home_id)
+            .order_by(HomeApiKey.created_at.desc())
+        )
+        return list(self.db.scalars(stmt))
+
+    def get_by_hash(self, key_hash: str) -> HomeApiKey | None:
+        stmt = select(HomeApiKey).where(HomeApiKey.key_hash == key_hash)
+        return self.db.scalar(stmt)
+
+    def get_by_id(self, key_id: str, home_id: str) -> HomeApiKey | None:
+        stmt = select(HomeApiKey).where(
+            HomeApiKey.id == key_id,
+            HomeApiKey.home_id == home_id,
+        )
+        return self.db.scalar(stmt)
+
+    def update_last_used(self, key: HomeApiKey) -> None:
+        key.last_used_at = datetime.now(timezone.utc)
+        self.db.commit()
+
+    def delete(self, key: HomeApiKey) -> None:
+        self.db.delete(key)
+        self.db.commit()

--- a/apps/api/vivian_api/routers/api_keys.py
+++ b/apps/api/vivian_api/routers/api_keys.py
@@ -1,0 +1,133 @@
+"""API key management endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from vivian_api.auth.dependencies import CurrentUserContext, get_current_user_context, require_roles
+from vivian_api.auth.security import generate_api_key
+from vivian_api.db.database import get_db
+from vivian_api.repositories.api_key_repository import ApiKeyRepository
+
+router = APIRouter(tags=["api-keys"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class ApiKeyCreateRequest(BaseModel):
+    name: str
+
+
+class ApiKeyCreatedResponse(BaseModel):
+    id: str
+    name: str
+    prefix: str
+    created_at: datetime
+    key: str  # Full key — only returned on creation
+
+
+class ApiKeyListItem(BaseModel):
+    id: str
+    name: str
+    prefix: str
+    created_at: datetime
+    last_used_at: datetime | None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_default_home_id(ctx: CurrentUserContext) -> str:
+    membership = ctx.default_membership
+    if not membership:
+        raise HTTPException(status_code=400, detail="No default home found")
+    return str(membership.home_id)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/home/api-keys",
+    response_model=ApiKeyCreatedResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_api_key(
+    body: ApiKeyCreateRequest,
+    ctx: CurrentUserContext = Depends(require_roles("owner")),
+    db: Session = Depends(get_db),
+) -> ApiKeyCreatedResponse:
+    """Create a new named API key for the home. Returns full key once."""
+    home_id = _get_default_home_id(ctx)
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="Key name cannot be empty")
+
+    full_key, key_hash, prefix = generate_api_key()
+    repo = ApiKeyRepository(db)
+    key_record = repo.create(
+        home_id=home_id,
+        name=name,
+        key_hash=key_hash,
+        key_prefix=prefix,
+        created_by=ctx.user.id,
+    )
+
+    return ApiKeyCreatedResponse(
+        id=key_record.id,
+        name=key_record.name,
+        prefix=key_record.key_prefix,
+        created_at=key_record.created_at,
+        key=full_key,
+    )
+
+
+@router.get("/home/api-keys", response_model=list[ApiKeyListItem])
+def list_api_keys(
+    ctx: CurrentUserContext = Depends(get_current_user_context),
+    db: Session = Depends(get_db),
+) -> list[ApiKeyListItem]:
+    """List all API keys for the home (no plaintext key or hash exposed)."""
+    home_id = _get_default_home_id(ctx)
+    repo = ApiKeyRepository(db)
+    keys = repo.list_by_home(home_id)
+    return [
+        ApiKeyListItem(
+            id=k.id,
+            name=k.name,
+            prefix=k.key_prefix,
+            created_at=k.created_at,
+            last_used_at=k.last_used_at,
+        )
+        for k in keys
+    ]
+
+
+@router.delete(
+    "/home/api-keys/{key_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_api_key(
+    key_id: str,
+    ctx: CurrentUserContext = Depends(require_roles("owner")),
+    db: Session = Depends(get_db),
+) -> None:
+    """Revoke an API key."""
+    home_id = _get_default_home_id(ctx)
+    repo = ApiKeyRepository(db)
+    key_record = repo.get_by_id(key_id, home_id)
+    if not key_record:
+        raise HTTPException(status_code=404, detail="API key not found")
+    repo.delete(key_record)

--- a/apps/api/vivian_api/routers/integrations.py
+++ b/apps/api/vivian_api/routers/integrations.py
@@ -207,7 +207,7 @@ async def get_google_status(
 @router.get("/google/oauth/start")
 async def start_google_oauth(
     return_to: str = Query(default="", description="Where to send user after OAuth"),
-    current_user: CurrentUserContext = Depends(require_roles("owner", "parent")),
+    current_user: CurrentUserContext = Depends(require_roles("owner")),
 ):
     """Start Google OAuth flow and redirect to consent screen."""
     client_id = get_google_client_id(settings)

--- a/apps/api/vivian_api/routers/internal.py
+++ b/apps/api/vivian_api/routers/internal.py
@@ -1,0 +1,66 @@
+"""Internal API endpoints for the MCP server and other internal consumers.
+
+NOTE: These endpoints are intended for internal Docker network use only.
+Infrastructure-level network policy enforces this; no additional network auth
+is applied beyond the API key check.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from vivian_api.auth.dependencies import ApiKeyContext, get_home_from_api_key
+from vivian_api.config import Settings
+from vivian_api.db.database import get_db
+from vivian_api.repositories.connection_repository import HomeConnectionRepository
+
+router = APIRouter(tags=["internal"])
+
+settings = Settings()
+
+
+class GoogleTokenResponse(BaseModel):
+    refresh_token: str
+    email: str | None
+
+
+@router.get("/internal/google-token", response_model=GoogleTokenResponse)
+def get_google_token(
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> GoogleTokenResponse:
+    """Return the Google refresh token for the API key's home.
+
+    Used by the MCP server to obtain Google credentials without storing them
+    locally.
+
+    Returns:
+        200: { refresh_token, email }
+        401: invalid_api_key (handled by get_home_from_api_key)
+        404: google_not_connected
+    """
+    repo = HomeConnectionRepository(db)
+    connection = repo.get_by_home_and_provider(
+        api_key_ctx.home_id,
+        provider="google",
+        connection_type="drive_sheets",
+    )
+
+    if not connection:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "google_not_connected",
+                "message": "Google account not connected for this home.",
+                "action": "Ask your admin to connect Google in Settings.",
+                "settings_url": f"{settings.vivian_url}/settings/connections",
+            },
+        )
+
+    refresh_token = repo.get_decrypted_refresh_token(connection)
+    return GoogleTokenResponse(
+        refresh_token=refresh_token,
+        email=connection.provider_email,
+    )


### PR DESCRIPTION
## Summary

- **Migration 0004**: adds `home_api_keys` table (SHA-256 hash, key prefix, `last_used_at`)
- **API key CRUD**: `POST/GET /api/v1/home/api-keys`, `DELETE /api/v1/home/api-keys/{id}` — owner only
- **Internal token endpoint**: `GET /api/v1/internal/google-token` — authenticated via `viv_sk_...` API key, returns Google refresh token + email for the MCP server
- **`get_home_from_api_key` dependency**: validates API key, updates `last_used_at`, returns home context
- **Config**: adds `vivian_url` setting; new `.env.example` with all vars including `VIVIAN_API_VIVIAN_URL`
- **Google OAuth**: restrict `oauth/start` to `owner` only (was `owner` + `parent`)
- **CLAUDE.md / AGENTS.md**: embed shared rules inline, fix `venv → uv`, add branch hygiene to code review policy

## Test plan

- [ ] Run migration: `cd apps/api && DATABASE_URL="postgresql://postgres:postgres@localhost:5432/vivian" uv run alembic upgrade head`
- [ ] Login as owner → create key → full key shown once in response
- [ ] `GET /api/v1/home/api-keys` → list with prefix + `last_used_at`, no plaintext key
- [ ] `DELETE /api/v1/home/api-keys/{id}` → 204, row gone
- [ ] `curl -H "Authorization: Bearer viv_sk_..."` → 200 with `refresh_token` + `email`
- [ ] Bad key → 401 `invalid_api_key`
- [ ] Valid key, no Google connection → 404 `google_not_connected` with `settings_url`
- [ ] After call: confirm `last_used_at` updated in DB
- [ ] Non-owner hitting create/delete → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)