### PR TITLE
feat: HSA + charitable ledger tools via self-bootstrapping Drive config

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "cryptography>=41.0.0",
     "mcp>=1.0.0",
+    "google-api-python-client>=2.0",
+    "google-auth>=2.0",
     "vivian-shared",
 ]
 

--- a/apps/api/vivian_api/routers/internal.py
+++ b/apps/api/vivian_api/routers/internal.py
@@ -7,7 +7,11 @@ is applied beyond the API key check.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -15,10 +19,83 @@ from vivian_api.auth.dependencies import ApiKeyContext, get_home_from_api_key
 from vivian_api.config import Settings
 from vivian_api.db.database import get_db
 from vivian_api.repositories.connection_repository import HomeConnectionRepository
+from vivian_api.services.drive_config import get_or_create_config
+from vivian_api.services.google_sheets import (
+    append_row,
+    build_google_credentials,
+    get_drive_service,
+    get_sheets_service,
+    read_rows,
+)
 
 router = APIRouter(tags=["internal"])
 
 settings = Settings()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _pad(row: list, length: int) -> list[str]:
+    """Pad a row to *length* with empty strings."""
+    row = list(row)
+    while len(row) < length:
+        row.append("")
+    return [str(v) for v in row]
+
+
+def _row_to_hsa_entry(row: list) -> dict:
+    r = _pad(row, 11)
+    return {
+        "id": r[0],
+        "provider": r[1],
+        "service_date": r[2],
+        "paid_date": r[3],
+        "amount": _to_float(r[4]),
+        "hsa_eligible": r[5],
+        "status": r[6],
+        "reimbursement_date": r[7],
+        "drive_file_id": r[8],
+        "confidence": r[9],
+        "created_at": r[10],
+    }
+
+
+def _row_to_donation_entry(row: list) -> dict:
+    r = _pad(row, 10)
+    return {
+        "id": r[0],
+        "organization_name": r[1],
+        "donation_date": r[2],
+        "amount": _to_float(r[3]),
+        "tax_deductible": r[4],
+        "description": r[5],
+        "drive_file_id": r[6],
+        "tax_year": r[7],
+        "confidence": r[8],
+        "created_at": r[9],
+    }
+
+
+def _to_float(val: str) -> float:
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _year_matches(date_str: str, year: int) -> bool:
+    return date_str.startswith(str(year))
+
+
+# ---------------------------------------------------------------------------
+# Existing endpoint
+# ---------------------------------------------------------------------------
 
 
 class GoogleTokenResponse(BaseModel):
@@ -64,3 +141,274 @@ def get_google_token(
         refresh_token=refresh_token,
         email=connection.provider_email,
     )
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+@router.get("/internal/capabilities")
+def get_capabilities(
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return which features are available for the home.
+
+    Always includes setup_url so clients can surface it when a feature is
+    not yet available.
+    """
+    repo = HomeConnectionRepository(db)
+    connection = repo.get_by_home_and_provider(
+        api_key_ctx.home_id,
+        provider="google",
+        connection_type="drive_sheets",
+    )
+    return {
+        "google_connected": bool(connection),
+        "setup_url": f"{settings.vivian_url}/settings/connections",
+    }
+
+
+# ---------------------------------------------------------------------------
+# HSA endpoints
+# ---------------------------------------------------------------------------
+
+
+class HSAExpenseBody(BaseModel):
+    provider: str
+    amount: float
+    service_date: Optional[str] = None
+    paid_date: Optional[str] = None
+    hsa_eligible: bool = True
+    status: str = "unreimbursed"
+    reimbursement_date: Optional[str] = None
+    drive_file_id: Optional[str] = None
+
+
+@router.post("/internal/hsa/expenses")
+async def create_hsa_expense(
+    body: HSAExpenseBody,
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Log a new HSA expense to the home's Ledger sheet."""
+    try:
+        cfg = await get_or_create_config(api_key_ctx.home_id, db, settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    creds = build_google_credentials(api_key_ctx.home_id, db, settings)
+    sheets_svc = get_sheets_service(creds)
+
+    expense_id = str(uuid.uuid4())
+    row = [
+        expense_id,
+        body.provider,
+        body.service_date or "",
+        body.paid_date or "",
+        str(body.amount),
+        str(body.hsa_eligible).lower(),
+        body.status,
+        body.reimbursement_date or "",
+        body.drive_file_id or "",
+        "",  # confidence
+        _now_iso(),
+    ]
+    append_row(sheets_svc, cfg["hsa_ledger_id"], "Sheet1", row)
+    return {"success": True, "id": expense_id}
+
+
+@router.get("/internal/hsa/expenses")
+async def list_hsa_expenses(
+    year: Optional[int] = Query(None),
+    status_filter: Optional[str] = Query(None, enum=["reimbursed", "unreimbursed", "not_hsa_eligible"]),
+    limit: int = Query(100, ge=1, le=5000),
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    """List HSA expenses with optional year and status filtering."""
+    try:
+        cfg = await get_or_create_config(api_key_ctx.home_id, db, settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    creds = build_google_credentials(api_key_ctx.home_id, db, settings)
+    sheets_svc = get_sheets_service(creds)
+
+    rows = read_rows(sheets_svc, cfg["hsa_ledger_id"], "Sheet1")
+    entries = [_row_to_hsa_entry(r) for r in rows]
+
+    if year:
+        entries = [
+            e for e in entries
+            if _year_matches(e["service_date"], year) or _year_matches(e["paid_date"], year)
+        ]
+    if status_filter:
+        entries = [e for e in entries if e["status"] == status_filter]
+
+    entries = entries[:limit]
+
+    total_amount = sum(e["amount"] for e in entries)
+    total_reimbursed = sum(e["amount"] for e in entries if e["status"] == "reimbursed")
+    total_unreimbursed = sum(e["amount"] for e in entries if e["status"] == "unreimbursed")
+    total_not_eligible = sum(e["amount"] for e in entries if e["status"] == "not_hsa_eligible")
+    count_reimbursed = sum(1 for e in entries if e["status"] == "reimbursed")
+    count_unreimbursed = sum(1 for e in entries if e["status"] == "unreimbursed")
+    count_not_eligible = sum(1 for e in entries if e["status"] == "not_hsa_eligible")
+
+    return {
+        "success": True,
+        "entries": entries,
+        "summary": {
+            "total_entries": len(entries),
+            "total_amount": total_amount,
+            "total_reimbursed": total_reimbursed,
+            "total_unreimbursed": total_unreimbursed,
+            "total_not_eligible": total_not_eligible,
+            "count_reimbursed": count_reimbursed,
+            "count_unreimbursed": count_unreimbursed,
+            "count_not_eligible": count_not_eligible,
+            "available_to_reimburse": total_unreimbursed,
+        },
+    }
+
+
+@router.get("/internal/hsa/balance")
+async def get_hsa_balance(
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return the total unreimbursed HSA balance."""
+    try:
+        cfg = await get_or_create_config(api_key_ctx.home_id, db, settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    creds = build_google_credentials(api_key_ctx.home_id, db, settings)
+    sheets_svc = get_sheets_service(creds)
+
+    rows = read_rows(sheets_svc, cfg["hsa_ledger_id"], "Sheet1")
+    unreimbursed = [
+        _row_to_hsa_entry(r) for r in rows
+        if len(r) > 6 and r[6] == "unreimbursed"
+    ]
+    return {
+        "total_unreimbursed": sum(e["amount"] for e in unreimbursed),
+        "count": len(unreimbursed),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Charitable endpoints
+# ---------------------------------------------------------------------------
+
+
+class CharitableEntryBody(BaseModel):
+    organization_name: str
+    amount: float
+    donation_date: Optional[str] = None
+    tax_deductible: bool = True
+    description: Optional[str] = None
+    tax_year: Optional[str] = None
+
+
+@router.post("/internal/charitable/entries")
+async def create_charitable_entry(
+    body: CharitableEntryBody,
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Log a new charitable donation to the home's Donations Ledger sheet."""
+    try:
+        cfg = await get_or_create_config(api_key_ctx.home_id, db, settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    creds = build_google_credentials(api_key_ctx.home_id, db, settings)
+    sheets_svc = get_sheets_service(creds)
+
+    entry_id = str(uuid.uuid4())
+    tax_year = body.tax_year or str(datetime.now(timezone.utc).year)
+    row = [
+        entry_id,
+        body.organization_name,
+        body.donation_date or "",
+        str(body.amount),
+        str(body.tax_deductible).lower(),
+        body.description or "",
+        "",  # drive_file_id
+        tax_year,
+        "",  # confidence
+        _now_iso(),
+    ]
+    append_row(sheets_svc, cfg["donations_ledger_id"], "Sheet1", row)
+    return {"success": True, "id": entry_id}
+
+
+@router.get("/internal/charitable/entries")
+async def list_charitable_entries(
+    tax_year: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=5000),
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    """List charitable donations with optional tax year filtering."""
+    try:
+        cfg = await get_or_create_config(api_key_ctx.home_id, db, settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    creds = build_google_credentials(api_key_ctx.home_id, db, settings)
+    sheets_svc = get_sheets_service(creds)
+
+    rows = read_rows(sheets_svc, cfg["donations_ledger_id"], "Sheet1")
+    entries = [_row_to_donation_entry(r) for r in rows]
+
+    if tax_year:
+        entries = [e for e in entries if e["tax_year"] == tax_year]
+
+    entries = entries[:limit]
+    return {"success": True, "entries": entries}
+
+
+@router.get("/internal/charitable/summary")
+async def get_charitable_summary(
+    tax_year: Optional[str] = Query(None),
+    api_key_ctx: ApiKeyContext = Depends(get_home_from_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return charitable donation totals and breakdown by organization."""
+    try:
+        cfg = await get_or_create_config(api_key_ctx.home_id, db, settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    creds = build_google_credentials(api_key_ctx.home_id, db, settings)
+    sheets_svc = get_sheets_service(creds)
+
+    rows = read_rows(sheets_svc, cfg["donations_ledger_id"], "Sheet1")
+    entries = [_row_to_donation_entry(r) for r in rows]
+
+    if tax_year:
+        entries = [e for e in entries if e["tax_year"] == tax_year]
+
+    total = sum(e["amount"] for e in entries)
+    tax_deductible_total = sum(
+        e["amount"] for e in entries if e["tax_deductible"].lower() == "true"
+    )
+
+    by_organization: dict[str, float] = {}
+    by_year: dict[str, float] = {}
+    for e in entries:
+        org = e["organization_name"]
+        yr = e["tax_year"]
+        by_organization[org] = by_organization.get(org, 0.0) + e["amount"]
+        by_year[yr] = by_year.get(yr, 0.0) + e["amount"]
+
+    return {
+        "total": total,
+        "tax_deductible_total": tax_deductible_total,
+        "by_organization": by_organization,
+        "by_year": by_year,
+    }

--- a/apps/api/vivian_api/routers/ledger.py
+++ b/apps/api/vivian_api/routers/ledger.py
@@ -16,8 +16,12 @@ from vivian_api.auth.dependencies import (
 from vivian_api.config import Settings
 from vivian_api.db.database import get_db
 from vivian_api.models.schemas import UnreimbursedBalanceResponse
-from vivian_api.services.mcp_client import MCPClient, extract_tool_result_payload
-from vivian_api.services.mcp_registry import get_mcp_server_definitions
+from vivian_api.services.drive_config import get_or_create_config
+from vivian_api.services.google_sheets import (
+    build_google_credentials,
+    get_sheets_service,
+    read_rows,
+)
 
 
 router = APIRouter(
@@ -74,26 +78,64 @@ def _get_default_home_id(current_user: CurrentUserContext) -> str:
     return current_user.default_membership.home_id
 
 
-async def _create_mcp_client(
-    mcp_server_id: str,
-    db: Session,
-    home_id: str,
-) -> MCPClient:
-    """Create an MCPClient with database-backed configuration."""
-    definitions = get_mcp_server_definitions(settings)
-    definition = definitions.get(mcp_server_id)
-    if not definition:
-        raise ValueError(f"Unknown MCP server: {mcp_server_id}")
+# ---------------------------------------------------------------------------
+# Row parsers
+# ---------------------------------------------------------------------------
 
-    from vivian_api.services.google_integration import build_mcp_env_from_db
-    env = await build_mcp_env_from_db(home_id, mcp_server_id, db, settings)
-    return MCPClient(
-        server_command=definition.command,
-        process_env=env,
-        server_path_override=definition.server_path,
-        mcp_server_id=mcp_server_id,
-    )
+def _pad(row: list, length: int) -> list[str]:
+    row = list(row)
+    while len(row) < length:
+        row.append("")
+    return [str(v) for v in row]
 
+
+def _to_float(val: str) -> float:
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _row_to_hsa_entry(row: list) -> dict:
+    r = _pad(row, 11)
+    return {
+        "id": r[0],
+        "provider": r[1],
+        "service_date": r[2],
+        "paid_date": r[3],
+        "amount": _to_float(r[4]),
+        "hsa_eligible": r[5],
+        "status": r[6],
+        "reimbursement_date": r[7],
+        "drive_file_id": r[8],
+        "confidence": r[9],
+        "created_at": r[10],
+    }
+
+
+def _row_to_donation_entry(row: list) -> dict:
+    r = _pad(row, 10)
+    return {
+        "id": r[0],
+        "organization_name": r[1],
+        "donation_date": r[2],
+        "amount": _to_float(r[3]),
+        "tax_deductible": r[4],
+        "description": r[5],
+        "drive_file_id": r[6],
+        "tax_year": r[7],
+        "confidence": r[8],
+        "created_at": r[9],
+    }
+
+
+def _year_matches(date_str: str, year: int) -> bool:
+    return date_str.startswith(str(year))
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
 
 @router.get("/balance/unreimbursed", response_model=UnreimbursedBalanceResponse)
 async def get_unreimbursed_balance(
@@ -101,144 +143,112 @@ async def get_unreimbursed_balance(
     db: Session = Depends(get_db),
 ):
     """Get total of all unreimbursed HSA expenses.
-    
-    Returns zero balance if MCP server is not configured or fails.
+
+    Returns zero balance if Google is not connected or the ledger is empty.
     """
     home_id = _get_default_home_id(current_user)
-    
+
     try:
-        mcp_client = await _create_mcp_client("hsa_ledger", db, home_id)
-        await mcp_client.start()
-        
-        try:
-            result = await mcp_client.get_unreimbursed_balance()
-            
-            if "error" in result and not result.get("total_unreimbursed"):
-                # MCP server responded with an error (likely spreadsheet not found)
-                logger.error("HSA balance MCP error: %s", result)
-                return UnreimbursedBalanceResponse(
-                    total_amount=0,
-                    count=0,
-                    is_configured=False
-                )
-            
-            return UnreimbursedBalanceResponse(
-                total_amount=result.get("total_unreimbursed", 0),
-                count=result.get("count", 0),
-                is_configured=True
-            )
-        finally:
-            await mcp_client.stop()
-            
+        cfg = await get_or_create_config(home_id, db, settings)
+        creds = build_google_credentials(home_id, db, settings)
+        sheets_svc = get_sheets_service(creds)
+
+        rows = read_rows(sheets_svc, cfg["hsa_ledger_id"], "Sheet1")
+        unreimbursed = [
+            _row_to_hsa_entry(r) for r in rows
+            if len(r) > 6 and r[6] == "unreimbursed"
+        ]
+        return UnreimbursedBalanceResponse(
+            total_amount=sum(e["amount"] for e in unreimbursed),
+            count=len(unreimbursed),
+            is_configured=True,
+        )
+
     except Exception as e:
-        # If MCP server isn't configured or fails to start, return not configured
         logger.error("HSA balance check failed: %s", e, exc_info=True)
         return UnreimbursedBalanceResponse(
             total_amount=0,
             count=0,
-            is_configured=False
+            is_configured=False,
         )
 
 
 @router.get("/summary", response_model=LedgerSummaryResponse)
 async def get_ledger_summary(
     year: Optional[int] = Query(None, description="Filter by year (e.g., 2025)"),
-    status_filter: Optional[str] = Query(None, description="Filter by status", enum=["reimbursed", "unreimbursed", "not_hsa_eligible"]),
+    status_filter: Optional[str] = Query(
+        None,
+        description="Filter by status",
+        enum=["reimbursed", "unreimbursed", "not_hsa_eligible"],
+    ),
     limit: int = Query(1000, description="Maximum entries to return", ge=1, le=5000),
     current_user: CurrentUserContext = Depends(get_current_user_context),
     db: Session = Depends(get_db),
 ):
-    """Get HSA ledger summary with optional filtering.
-    
-    This endpoint answers questions like:
-    - "How much have I reimbursed this year?"
-    - "How much is available to reimburse?"
-    - "What are my total HSA expenses?"
-    
-    Args:
-        year: Optional year to filter entries
-        status_filter: Optional status filter (reimbursed, unreimbursed, not_hsa_eligible)
-        limit: Maximum number of entries to return (default 1000)
-    """
+    """Get HSA ledger summary with optional filtering."""
     home_id = _get_default_home_id(current_user)
-    
-    mcp_client = await _create_mcp_client("hsa_ledger", db, home_id)
-    await mcp_client.start()
-    
+
+    _empty_summary = LedgerSummary(
+        total_entries=0,
+        total_amount=0,
+        total_reimbursed=0,
+        total_unreimbursed=0,
+        total_not_eligible=0,
+        count_reimbursed=0,
+        count_unreimbursed=0,
+        count_not_eligible=0,
+        available_to_reimburse=0,
+    )
+
     try:
-        result = await mcp_client.call_tool(
-            "read_ledger_entries",
-            {
-                "year": year,
-                "status_filter": status_filter,
-                "limit": limit
-            }
-        )
-        
-        # Parse the result
-        data = extract_tool_result_payload(result) or {}
-        if not isinstance(data, dict):
-            data = {}
-        
-        if not data.get("success"):
-            return LedgerSummaryResponse(
-                success=False,
-                year=year,
-                status_filter=status_filter,
-                summary=LedgerSummary(
-                    total_entries=0,
-                    total_amount=0,
-                    total_reimbursed=0,
-                    total_unreimbursed=0,
-                    total_not_eligible=0,
-                    count_reimbursed=0,
-                    count_unreimbursed=0,
-                    count_not_eligible=0,
-                    available_to_reimburse=0,
-                ),
-                error=data.get("error", "Failed to read ledger")
-            )
-        
-        summary_data = data.get("summary", {})
-        
+        cfg = await get_or_create_config(home_id, db, settings)
+        creds = build_google_credentials(home_id, db, settings)
+        sheets_svc = get_sheets_service(creds)
+
+        rows = read_rows(sheets_svc, cfg["hsa_ledger_id"], "Sheet1")
+        entries = [_row_to_hsa_entry(r) for r in rows]
+
+        if year:
+            entries = [
+                e for e in entries
+                if _year_matches(e["service_date"], year) or _year_matches(e["paid_date"], year)
+            ]
+        if status_filter:
+            entries = [e for e in entries if e["status"] == status_filter]
+
+        entries = entries[:limit]
+
+        total_reimbursed = sum(e["amount"] for e in entries if e["status"] == "reimbursed")
+        total_unreimbursed = sum(e["amount"] for e in entries if e["status"] == "unreimbursed")
+        total_not_eligible = sum(e["amount"] for e in entries if e["status"] == "not_hsa_eligible")
+
         return LedgerSummaryResponse(
             success=True,
             year=year,
             status_filter=status_filter,
             summary=LedgerSummary(
-                total_entries=summary_data.get("total_entries", 0),
-                total_amount=summary_data.get("total_amount", 0),
-                total_reimbursed=summary_data.get("total_reimbursed", 0),
-                total_unreimbursed=summary_data.get("total_unreimbursed", 0),
-                total_not_eligible=summary_data.get("total_not_eligible", 0),
-                count_reimbursed=summary_data.get("count_reimbursed", 0),
-                count_unreimbursed=summary_data.get("count_unreimbursed", 0),
-                count_not_eligible=summary_data.get("count_not_eligible", 0),
-                available_to_reimburse=summary_data.get("available_to_reimburse", 0),
+                total_entries=len(entries),
+                total_amount=sum(e["amount"] for e in entries),
+                total_reimbursed=total_reimbursed,
+                total_unreimbursed=total_unreimbursed,
+                total_not_eligible=total_not_eligible,
+                count_reimbursed=sum(1 for e in entries if e["status"] == "reimbursed"),
+                count_unreimbursed=sum(1 for e in entries if e["status"] == "unreimbursed"),
+                count_not_eligible=sum(1 for e in entries if e["status"] == "not_hsa_eligible"),
+                available_to_reimburse=total_unreimbursed,
             ),
-            entries=data.get("entries", [])
+            entries=entries,
         )
-        
+
     except Exception as e:
+        logger.error("Ledger summary failed: %s", e, exc_info=True)
         return LedgerSummaryResponse(
             success=False,
             year=year,
             status_filter=status_filter,
-            summary=LedgerSummary(
-                total_entries=0,
-                total_amount=0,
-                total_reimbursed=0,
-                total_unreimbursed=0,
-                total_not_eligible=0,
-                count_reimbursed=0,
-                count_unreimbursed=0,
-                count_not_eligible=0,
-                available_to_reimburse=0,
-            ),
-            error=f"Failed to get ledger summary: {str(e)}"
+            summary=_empty_summary,
+            error=f"Failed to get ledger summary: {e}",
         )
-    finally:
-        await mcp_client.stop()
 
 
 @router.get("/charitable/summary", response_model=CharitableSummaryResponse)
@@ -247,51 +257,46 @@ async def get_charitable_summary(
     current_user: CurrentUserContext = Depends(get_current_user_context),
     db: Session = Depends(get_db),
 ):
-    """Get summary of charitable donations by tax year.
-    
-    Args:
-        tax_year: Optional tax year to filter by (e.g., "2025")
-    """
+    """Get summary of charitable donations by tax year."""
     home_id = _get_default_home_id(current_user)
-    
-    mcp_client = await _create_mcp_client("charitable_ledger", db, home_id)
-    await mcp_client.start()
-    
+
     try:
-        payload: dict[str, str] = {}
+        cfg = await get_or_create_config(home_id, db, settings)
+        creds = build_google_credentials(home_id, db, settings)
+        sheets_svc = get_sheets_service(creds)
+
+        rows = read_rows(sheets_svc, cfg["donations_ledger_id"], "Sheet1")
+        entries = [_row_to_donation_entry(r) for r in rows]
+
         if tax_year:
-            payload["tax_year"] = tax_year
-        result = await mcp_client.call_tool(
-            "get_charitable_summary",
-            payload
+            entries = [e for e in entries if e["tax_year"] == tax_year]
+
+        total = sum(e["amount"] for e in entries)
+        tax_deductible_total = sum(
+            e["amount"] for e in entries if e["tax_deductible"].lower() == "true"
         )
-        
-        # Parse the result
-        data = extract_tool_result_payload(result) or {}
-        if not isinstance(data, dict):
-            data = {}
-        
-        if not data.get("success"):
-            return CharitableSummaryResponse(
-                success=False,
-                error=data.get("error", "Failed to get summary")
-            )
-        
+        by_organization: dict[str, float] = {}
+        by_year: dict[str, float] = {}
+        for e in entries:
+            org = e["organization_name"]
+            yr = e["tax_year"]
+            by_organization[org] = by_organization.get(org, 0.0) + e["amount"]
+            by_year[yr] = by_year.get(yr, 0.0) + e["amount"]
+
         return CharitableSummaryResponse(
             success=True,
             data=CharitableDonationSummary(
                 tax_year=tax_year,
-                total=data.get("total", 0),
-                tax_deductible_total=data.get("tax_deductible_total", 0),
-                by_organization=data.get("by_organization", {}),
-                by_year=data.get("by_year", {}),
-            )
+                total=total,
+                tax_deductible_total=tax_deductible_total,
+                by_organization=by_organization,
+                by_year=by_year,
+            ),
         )
-        
+
     except Exception as e:
+        logger.error("Charitable summary failed: %s", e, exc_info=True)
         return CharitableSummaryResponse(
             success=False,
-            error=f"Failed to get charitable summary: {str(e)}"
+            error=f"Failed to get charitable summary: {e}",
         )
-    finally:
-        await mcp_client.stop()

--- a/apps/api/vivian_api/services/drive_config.py
+++ b/apps/api/vivian_api/services/drive_config.py
@@ -1,0 +1,170 @@
+"""Drive structure bootstrap and per-home config cache.
+
+On first use, `get_or_create_config` checks Drive for an existing `.config`
+sheet under a `Vivian/` root folder.  If the sheet is missing, the full
+folder/sheet hierarchy is created and the IDs are written to `.config`.
+
+Subsequent calls return from the in-process cache (IDs never change).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from vivian_api.services.google_sheets import (
+    build_google_credentials,
+    create_folder,
+    create_sheet,
+    get_drive_service,
+    get_sheets_service,
+    search_drive,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+    from vivian_api.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# In-process cache — keyed by home_id.  IDs are permanent, so no TTL needed.
+_config_cache: dict[str, dict] = {}
+
+_HSA_HEADERS = [
+    "id",
+    "provider",
+    "service_date",
+    "paid_date",
+    "amount",
+    "hsa_eligible",
+    "status",
+    "reimbursement_date",
+    "drive_file_id",
+    "confidence",
+    "created_at",
+]
+
+_DONATIONS_HEADERS = [
+    "id",
+    "organization_name",
+    "donation_date",
+    "amount",
+    "tax_deductible",
+    "description",
+    "drive_file_id",
+    "tax_year",
+    "confidence",
+    "created_at",
+]
+
+_REQUIRED_KEYS = [
+    "hsa_folder_id",
+    "hsa_receipts_folder_id",
+    "hsa_ledger_id",
+    "donations_folder_id",
+    "donations_receipts_folder_id",
+    "donations_ledger_id",
+]
+
+
+async def get_or_create_config(home_id: str, db: "Session", settings: "Settings") -> dict:
+    """Return cached Drive config for home, bootstrapping if needed.
+
+    Returns a dict with keys:
+        hsa_folder_id, hsa_receipts_folder_id, hsa_ledger_id,
+        donations_folder_id, donations_receipts_folder_id, donations_ledger_id
+    """
+    if home_id in _config_cache:
+        return _config_cache[home_id]
+
+    creds = build_google_credentials(home_id, db, settings)
+    drive_svc = get_drive_service(creds)
+    sheets_svc = get_sheets_service(creds)
+
+    config = _read_config_sheet(drive_svc, sheets_svc)
+    if config is None:
+        config = _bootstrap_drive_structure(drive_svc, sheets_svc)
+
+    _config_cache[home_id] = config
+    return config
+
+
+def _read_config_sheet(drive_svc, sheets_svc) -> dict | None:
+    """Try to read IDs from the existing .config sheet. Returns None if absent."""
+    vivian_id = search_drive(drive_svc, "Vivian")
+    if not vivian_id:
+        return None
+
+    config_id = search_drive(drive_svc, ".config", parent_id=vivian_id)
+    if not config_id:
+        return None
+
+    result = (
+        sheets_svc.spreadsheets()
+        .values()
+        .get(spreadsheetId=config_id, range="Sheet1!A:B")
+        .execute()
+    )
+    config: dict[str, str] = {}
+    for row in result.get("values", []):
+        if len(row) >= 2:
+            config[row[0]] = row[1]
+
+    return config if all(k in config for k in _REQUIRED_KEYS) else None
+
+
+def _bootstrap_drive_structure(drive_svc, sheets_svc) -> dict:
+    """Create the Vivian/ folder hierarchy and return the resulting config."""
+    logger.info("Bootstrapping Vivian Drive structure")
+
+    vivian_id = search_drive(drive_svc, "Vivian") or create_folder(drive_svc, "Vivian")
+
+    # HSA branch
+    hsa_id = search_drive(drive_svc, "HSA", parent_id=vivian_id) or create_folder(
+        drive_svc, "HSA", parent_id=vivian_id
+    )
+    hsa_receipts_id = search_drive(
+        drive_svc, "Receipts", parent_id=hsa_id
+    ) or create_folder(drive_svc, "Receipts", parent_id=hsa_id)
+    hsa_ledger_id = search_drive(
+        drive_svc, "Ledger", parent_id=hsa_id
+    ) or create_sheet(drive_svc, sheets_svc, "Ledger", hsa_id, _HSA_HEADERS)
+
+    # Donations branch
+    donations_id = search_drive(
+        drive_svc, "Donations", parent_id=vivian_id
+    ) or create_folder(drive_svc, "Donations", parent_id=vivian_id)
+    donations_receipts_id = search_drive(
+        drive_svc, "Receipts", parent_id=donations_id
+    ) or create_folder(drive_svc, "Receipts", parent_id=donations_id)
+    donations_ledger_id = search_drive(
+        drive_svc, "Ledger", parent_id=donations_id
+    ) or create_sheet(
+        drive_svc, sheets_svc, "Ledger", donations_id, _DONATIONS_HEADERS
+    )
+
+    config = {
+        "hsa_folder_id": hsa_id,
+        "hsa_receipts_folder_id": hsa_receipts_id,
+        "hsa_ledger_id": hsa_ledger_id,
+        "donations_folder_id": donations_id,
+        "donations_receipts_folder_id": donations_receipts_id,
+        "donations_ledger_id": donations_ledger_id,
+    }
+    _write_config_sheet(drive_svc, sheets_svc, vivian_id, config)
+    logger.info("Drive bootstrap complete: %s", config)
+    return config
+
+
+def _write_config_sheet(drive_svc, sheets_svc, vivian_id: str, config: dict) -> None:
+    """Create the .config sheet and write key/value pairs starting at row 2."""
+    config_id = create_sheet(
+        drive_svc, sheets_svc, ".config", vivian_id, ["key", "value"]
+    )
+    rows = [[k, v] for k, v in config.items()]
+    sheets_svc.spreadsheets().values().update(
+        spreadsheetId=config_id,
+        range="Sheet1!A2",
+        valueInputOption="USER_ENTERED",
+        body={"values": rows},
+    ).execute()

--- a/apps/api/vivian_api/services/google_sheets.py
+++ b/apps/api/vivian_api/services/google_sheets.py
@@ -1,0 +1,148 @@
+"""Google Sheets and Drive service helpers.
+
+Builds Google credentials from per-home DB connections, then wraps common
+Sheets/Drive operations used by the drive_config bootstrap and internal endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from vivian_api.services.google_integration import (
+    get_google_client_id,
+    get_google_client_secret,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+    from vivian_api.config import Settings
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+
+def build_google_credentials(home_id: str, db: "Session", settings: "Settings"):
+    """Build Google OAuth2 credentials for a home using the DB connection."""
+    import google.oauth2.credentials
+    from vivian_api.repositories.connection_repository import HomeConnectionRepository
+
+    repo = HomeConnectionRepository(db)
+    connection = repo.get_by_home_and_provider(
+        home_id=home_id,
+        provider="google",
+        connection_type="drive_sheets",
+    )
+    if not connection:
+        raise ValueError(f"Google not connected for home {home_id!r}")
+
+    refresh_token = repo.get_decrypted_refresh_token(connection)
+    client_id = get_google_client_id(settings)
+    client_secret = get_google_client_secret(settings)
+
+    return google.oauth2.credentials.Credentials(
+        token=None,
+        refresh_token=refresh_token,
+        token_uri=_TOKEN_URI,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+
+def get_sheets_service(creds):
+    """Build Google Sheets API v4 service."""
+    from googleapiclient.discovery import build
+
+    return build("sheets", "v4", credentials=creds)
+
+
+def get_drive_service(creds):
+    """Build Google Drive API v3 service."""
+    from googleapiclient.discovery import build
+
+    return build("drive", "v3", credentials=creds)
+
+
+def append_row(sheets_svc, spreadsheet_id: str, worksheet: str, values: list) -> None:
+    """Append a row to a Google Sheet worksheet."""
+    sheets_svc.spreadsheets().values().append(
+        spreadsheetId=spreadsheet_id,
+        range=f"{worksheet}!A:A",
+        valueInputOption="USER_ENTERED",
+        insertDataOption="INSERT_ROWS",
+        body={"values": [values]},
+    ).execute()
+
+
+def read_rows(sheets_svc, spreadsheet_id: str, worksheet: str) -> list[list[str]]:
+    """Read data rows from a worksheet. Row 1 (header) is skipped."""
+    result = (
+        sheets_svc.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=f"{worksheet}!A:Z")
+        .execute()
+    )
+    rows = result.get("values", [])
+    return rows[1:] if len(rows) > 1 else []
+
+
+def search_drive(drive_svc, name: str, parent_id: Optional[str] = None) -> Optional[str]:
+    """Search Drive for a file/folder by name. Returns file ID or None."""
+    query = f"name = '{name}' and trashed = false"
+    if parent_id:
+        query += f" and '{parent_id}' in parents"
+    result = drive_svc.files().list(q=query, fields="files(id)", pageSize=1).execute()
+    files = result.get("files", [])
+    return files[0]["id"] if files else None
+
+
+def create_folder(drive_svc, name: str, parent_id: Optional[str] = None) -> str:
+    """Create a Drive folder. Returns new folder ID."""
+    metadata: dict = {
+        "name": name,
+        "mimeType": "application/vnd.google-apps.folder",
+    }
+    if parent_id:
+        metadata["parents"] = [parent_id]
+    folder = drive_svc.files().create(body=metadata, fields="id").execute()
+    return folder["id"]
+
+
+def create_sheet(
+    drive_svc,
+    sheets_svc,
+    name: str,
+    parent_id: str,
+    headers: list[str],
+) -> str:
+    """Create a Google Sheet with a header row inside a Drive folder.
+
+    Returns the new spreadsheet ID.
+    """
+    # Create spreadsheet via Sheets API (ensures correct title)
+    spreadsheet = sheets_svc.spreadsheets().create(
+        body={"properties": {"title": name}},
+        fields="spreadsheetId",
+    ).execute()
+    spreadsheet_id = spreadsheet["spreadsheetId"]
+
+    # Move into the target Drive folder
+    file_data = drive_svc.files().get(fileId=spreadsheet_id, fields="parents").execute()
+    current_parents = ",".join(file_data.get("parents", []))
+    drive_svc.files().update(
+        fileId=spreadsheet_id,
+        addParents=parent_id,
+        removeParents=current_parents,
+        fields="id",
+    ).execute()
+
+    # Write header row
+    sheets_svc.spreadsheets().values().update(
+        spreadsheetId=spreadsheet_id,
+        range="Sheet1!A1",
+        valueInputOption="USER_ENTERED",
+        body={"values": [headers]},
+    ).execute()
+
+    return spreadsheet_id

--- a/apps/api/vivian_api/services/mcp_registry.py
+++ b/apps/api/vivian_api/services/mcp_registry.py
@@ -105,11 +105,7 @@ def get_mcp_server_definitions(settings: Settings) -> dict[str, MCPServerDefinit
             ],
             source="builtin",
             requires_connection="google",
-            required_settings=[
-                {"key": "drive_reimbursed_folder_id", "label": "Reimbursed Folder ID", "type": "folder_id"},
-                {"key": "drive_unreimbursed_folder_id", "label": "Unreimbursed Folder ID", "type": "folder_id"},
-                {"key": "spreadsheet_id", "label": "Spreadsheet ID", "type": "spreadsheet_id"},
-            ],
+            required_settings=[],  # Drive config self-bootstraps via .config sheet
         ),
         "charitable_ledger": MCPServerDefinition(
             id="charitable_ledger",
@@ -128,10 +124,7 @@ def get_mcp_server_definitions(settings: Settings) -> dict[str, MCPServerDefinit
             ],
             source="builtin",
             requires_connection="google",
-            required_settings=[
-                {"key": "drive_folder_id", "label": "Drive Folder ID", "type": "folder_id"},
-                {"key": "spreadsheet_id", "label": "Spreadsheet ID", "type": "spreadsheet_id"},
-            ],
+            required_settings=[],  # Drive config self-bootstraps via .config sheet
         ),
         "test_addition": MCPServerDefinition(
             id="test_addition",


### PR DESCRIPTION
## Summary

- **New service layer** (`google_sheets.py`, `drive_config.py`): vivian-backend now owns all Google Sheets/Drive logic — single source of truth reused by both the dashboard and MCP server
- **Self-bootstrapping Drive structure**: on first use, `get_or_create_config` creates `Vivian/.config`, `Vivian/HSA/Ledger`, `Vivian/Donations/Ledger` and caches IDs in-process — no manual folder/sheet ID configuration needed
- **7 new internal endpoints**: `GET /internal/capabilities` + 3 HSA endpoints + 3 charitable endpoints (POST expense/donation, GET list, GET balance/summary)
- **ledger.py migrated**: dashboard balance/summary/charitable routes now call the service layer directly instead of spawning MCPClient subprocesses
- **mcp_registry.py**: cleared `required_settings` for `hsa_ledger` + `charitable_ledger` — they can no longer be "blocked" waiting for manual IDs

## Drive structure (auto-created on first use)

```
Vivian/
├── .config               ← key/value store of all IDs
├── HSA/
│   ├── Receipts/
│   └── Ledger            ← Sheet1, 11 columns
└── Donations/
    ├── Receipts/
    └── Ledger            ← Sheet1, 10 columns
```

## Test plan

- [ ] `GET /api/v1/internal/capabilities` with API key → `{ google_connected: true/false, setup_url }`
- [ ] `POST /api/v1/internal/hsa/expenses` → triggers Drive bootstrap on first call, row appears in `Vivian/HSA/Ledger`
- [ ] `GET /api/v1/internal/hsa/balance` → returns unreimbursed total
- [ ] `GET /api/v1/internal/hsa/expenses?year=2025` → filtered list
- [ ] `POST /api/v1/internal/charitable/entries` → row in `Vivian/Donations/Ledger`
- [ ] `GET /api/v1/internal/charitable/summary` → totals + by_organization
- [ ] Second call to any endpoint → no Drive bootstrap (cache hit)
- [ ] `GET /api/v1/ledger/balance/unreimbursed` (dashboard) → no longer spawns MCPClient subprocess
- [ ] `GET /api/v1/ledger/summary` → works directly via Sheets service
- [ ] `GET /api/v1/ledger/charitable/summary` → same

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)